### PR TITLE
Add webrtc additional setting

### DIFF
--- a/src/en/index.html
+++ b/src/en/index.html
@@ -18,7 +18,6 @@
       href="../resources/assets/images/IDI_PIKAICON-0.png"
     />
   </head>
-
   <body>
     <div id="before-connection" class="limit-width">
       <div id="about-box-head">
@@ -156,42 +155,15 @@
           <button type="button" id="network-test-btn">Test network</button>
         </div>
         <p class="margin-top">
-          <button type="button" id="webrtc-settings-btn">
-            Advanced WebRtc Settings
-          </button>
+          <button type="button" id="webrtc-settings-btn">Advanced WebRtc Settings</button>
         </p>
         <div id="webrtc-settings-container" class="hidden">
           <label for="ice-server-url-input">Additional Ice Server url</label>
-          <input
-            type="text"
-            id="ice-server-url-input"
-            autocapitalize="none"
-            autocomplete="off"
-            autocorrect="off"
-            value=""
-          />
-          <label for="ice-server-username-input"
-            >Additional Ice Server username</label
-          >
-          <input
-            type="text"
-            id="ice-server-username-input"
-            autocapitalize="none"
-            autocomplete="off"
-            autocorrect="off"
-            value=""
-          />
-          <label for="ice-server-credential-input"
-            >Additional Ice Server credential</label
-          >
-          <input
-            type="text"
-            id="ice-server-credential-input"
-            autocapitalize="none"
-            autocomplete="off"
-            autocorrect="off"
-            value=""
-          />
+          <input type="text" id="ice-server-url-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <label for="ice-server-user-input">Additional Ice Server user</label>
+          <input type="text" id="ice-server-user-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <label for="ice-server-pass-input">Additional Ice Server pass</label>
+          <input type="text" id="ice-server-pass-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
         </div>
         <div>
           <p class="margin-top">

--- a/src/en/index.html
+++ b/src/en/index.html
@@ -18,6 +18,7 @@
       href="../resources/assets/images/IDI_PIKAICON-0.png"
     />
   </head>
+
   <body>
     <div id="before-connection" class="limit-width">
       <div id="about-box-head">
@@ -155,15 +156,42 @@
           <button type="button" id="network-test-btn">Test network</button>
         </div>
         <p class="margin-top">
-          <button type="button" id="webrtc-settings-btn">Advanced WebRtc Settings</button>
+          <button type="button" id="webrtc-settings-btn">
+            Advanced WebRtc Settings
+          </button>
         </p>
         <div id="webrtc-settings-container" class="hidden">
           <label for="ice-server-url-input">Additional Ice Server url</label>
-          <input type="text" id="ice-server-url-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
-          <label for="ice-server-user-input">Additional Ice Server user</label>
-          <input type="text" id="ice-server-user-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
-          <label for="ice-server-pass-input">Additional Ice Server pass</label>
-          <input type="text" id="ice-server-pass-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <input
+            type="text"
+            id="ice-server-url-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
+          <label for="ice-server-username-input"
+            >Additional Ice Server username</label
+          >
+          <input
+            type="text"
+            id="ice-server-username-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
+          <label for="ice-server-credential-input"
+            >Additional Ice Server credential</label
+          >
+          <input
+            type="text"
+            id="ice-server-credential-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
         </div>
         <div>
           <p class="margin-top">

--- a/src/en/index.html
+++ b/src/en/index.html
@@ -155,15 +155,38 @@
           <button type="button" id="network-test-btn">Test network</button>
         </div>
         <p class="margin-top">
-          <button type="button" id="webrtc-settings-btn">Advanced WebRtc Settings</button>
+          <button type="button" id="webrtc-settings-btn">
+            Advanced WebRtc Settings
+          </button>
         </p>
         <div id="webrtc-settings-container" class="hidden">
           <label for="ice-server-url-input">Additional Ice Server url</label>
-          <input type="text" id="ice-server-url-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <input
+            type="text"
+            id="ice-server-url-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
           <label for="ice-server-user-input">Additional Ice Server user</label>
-          <input type="text" id="ice-server-user-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <input
+            type="text"
+            id="ice-server-user-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
           <label for="ice-server-pass-input">Additional Ice Server pass</label>
-          <input type="text" id="ice-server-pass-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <input
+            type="text"
+            id="ice-server-pass-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
         </div>
         <div>
           <p class="margin-top">

--- a/src/en/index.html
+++ b/src/en/index.html
@@ -154,6 +154,17 @@
           </p>
           <button type="button" id="network-test-btn">Test network</button>
         </div>
+        <p class="margin-top">
+          <button type="button" id="webrtc-settings-btn">Advanced WebRtc Settings</button>
+        </p>
+        <div id="webrtc-settings-container" class="hidden">
+          <label for="ice-server-url-input">Additional Ice Server url</label>
+          <input type="text" id="ice-server-url-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <label for="ice-server-user-input">Additional Ice Server user</label>
+          <input type="text" id="ice-server-user-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <label for="ice-server-pass-input">Additional Ice Server pass</label>
+          <input type="text" id="ice-server-pass-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+        </div>
         <div>
           <p class="margin-top">
             <span class="thick">Controls:</span> Use the one comfortable for

--- a/src/ko/index.html
+++ b/src/ko/index.html
@@ -154,6 +154,17 @@
           </p>
           <button type="button" id="network-test-btn">네트워크 검사하기</button>
         </div>
+        <p class="margin-top">
+          <button type="button" id="webrtc-settings-btn">고급 webrtc 설정</button>
+        </p>
+        <div id="webrtc-settings-container" class="hidden">
+          <label for="ice-server-url-input">추가 Ice Server url</label>
+          <input type="text" id="ice-server-url-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <label for="ice-server-user-input">추가 Ice Server user</label>
+          <input type="text" id="ice-server-user-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <label for="ice-server-pass-input">추가 Ice Server pass</label>
+          <input type="text" id="ice-server-pass-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+        </div>
         <div>
           <p class="margin-top">
             <span class="thick">조작법:</span> 다음 중 편한 쪽을 사용하면

--- a/src/ko/index.html
+++ b/src/ko/index.html
@@ -18,6 +18,7 @@
       href="../resources/assets/images/IDI_PIKAICON-0.png"
     />
   </head>
+
   <body>
     <div id="before-connection" class="limit-width">
       <div id="about-box-head">
@@ -155,15 +156,42 @@
           <button type="button" id="network-test-btn">네트워크 검사하기</button>
         </div>
         <p class="margin-top">
-          <button type="button" id="webrtc-settings-btn">고급 webrtc 설정</button>
+          <button type="button" id="webrtc-settings-btn">
+            고급 webrtc 설정
+          </button>
         </p>
         <div id="webrtc-settings-container" class="hidden">
           <label for="ice-server-url-input">추가 Ice Server url</label>
-          <input type="text" id="ice-server-url-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
-          <label for="ice-server-user-input">추가 Ice Server user</label>
-          <input type="text" id="ice-server-user-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
-          <label for="ice-server-pass-input">추가 Ice Server pass</label>
-          <input type="text" id="ice-server-pass-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <input
+            type="text"
+            id="ice-server-url-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
+          <label for="ice-server-username-input"
+            >추가 Ice Server username</label
+          >
+          <input
+            type="text"
+            id="ice-server-username-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
+          <label for="ice-server-credential-input"
+            >추가 Ice Server credential</label
+          >
+          <input
+            type="text"
+            id="ice-server-credential-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
         </div>
         <div>
           <p class="margin-top">

--- a/src/ko/index.html
+++ b/src/ko/index.html
@@ -18,7 +18,6 @@
       href="../resources/assets/images/IDI_PIKAICON-0.png"
     />
   </head>
-
   <body>
     <div id="before-connection" class="limit-width">
       <div id="about-box-head">
@@ -156,42 +155,15 @@
           <button type="button" id="network-test-btn">네트워크 검사하기</button>
         </div>
         <p class="margin-top">
-          <button type="button" id="webrtc-settings-btn">
-            고급 webrtc 설정
-          </button>
+          <button type="button" id="webrtc-settings-btn">고급 webrtc 설정</button>
         </p>
         <div id="webrtc-settings-container" class="hidden">
           <label for="ice-server-url-input">추가 Ice Server url</label>
-          <input
-            type="text"
-            id="ice-server-url-input"
-            autocapitalize="none"
-            autocomplete="off"
-            autocorrect="off"
-            value=""
-          />
-          <label for="ice-server-username-input"
-            >추가 Ice Server username</label
-          >
-          <input
-            type="text"
-            id="ice-server-username-input"
-            autocapitalize="none"
-            autocomplete="off"
-            autocorrect="off"
-            value=""
-          />
-          <label for="ice-server-credential-input"
-            >추가 Ice Server credential</label
-          >
-          <input
-            type="text"
-            id="ice-server-credential-input"
-            autocapitalize="none"
-            autocomplete="off"
-            autocorrect="off"
-            value=""
-          />
+          <input type="text" id="ice-server-url-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <label for="ice-server-user-input">추가 Ice Server user</label>
+          <input type="text" id="ice-server-user-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <label for="ice-server-pass-input">추가 Ice Server pass</label>
+          <input type="text" id="ice-server-pass-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
         </div>
         <div>
           <p class="margin-top">

--- a/src/ko/index.html
+++ b/src/ko/index.html
@@ -155,15 +155,38 @@
           <button type="button" id="network-test-btn">네트워크 검사하기</button>
         </div>
         <p class="margin-top">
-          <button type="button" id="webrtc-settings-btn">고급 webrtc 설정</button>
+          <button type="button" id="webrtc-settings-btn">
+            고급 webrtc 설정
+          </button>
         </p>
         <div id="webrtc-settings-container" class="hidden">
           <label for="ice-server-url-input">추가 Ice Server url</label>
-          <input type="text" id="ice-server-url-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <input
+            type="text"
+            id="ice-server-url-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
           <label for="ice-server-user-input">추가 Ice Server user</label>
-          <input type="text" id="ice-server-user-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <input
+            type="text"
+            id="ice-server-user-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
           <label for="ice-server-pass-input">추가 Ice Server pass</label>
-          <input type="text" id="ice-server-pass-input" autocapitalize="none" autocomplete="off" autocorrect="off" value="" />
+          <input
+            type="text"
+            id="ice-server-pass-input"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            value=""
+          />
         </div>
         <div>
           <p class="margin-top">

--- a/src/resources/assets/images/sprite_sheet.json
+++ b/src/resources/assets/images/sprite_sheet.json
@@ -1,638 +1,609 @@
-{"frames": {
-
-"ball/ball_0.png":
 {
-	"frame": {"x":88,"y":158,"w":40,"h":40},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
-	"sourceSize": {"w":40,"h":40}
-},
-"ball/ball_1.png":
-{
-	"frame": {"x":130,"y":158,"w":40,"h":40},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
-	"sourceSize": {"w":40,"h":40}
-},
-"ball/ball_2.png":
-{
-	"frame": {"x":172,"y":158,"w":40,"h":40},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
-	"sourceSize": {"w":40,"h":40}
-},
-"ball/ball_3.png":
-{
-	"frame": {"x":214,"y":158,"w":40,"h":40},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
-	"sourceSize": {"w":40,"h":40}
-},
-"ball/ball_4.png":
-{
-	"frame": {"x":256,"y":158,"w":40,"h":40},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
-	"sourceSize": {"w":40,"h":40}
-},
-"ball/ball_hyper.png":
-{
-	"frame": {"x":298,"y":158,"w":40,"h":40},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
-	"sourceSize": {"w":40,"h":40}
-},
-"ball/ball_punch.png":
-{
-	"frame": {"x":340,"y":158,"w":40,"h":40},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
-	"sourceSize": {"w":40,"h":40}
-},
-"ball/ball_trail.png":
-{
-	"frame": {"x":382,"y":158,"w":40,"h":40},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
-	"sourceSize": {"w":40,"h":40}
-},
-"messages/common/game_end.png":
-{
-	"frame": {"x":124,"y":64,"w":96,"h":24},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":96,"h":24},
-	"sourceSize": {"w":96,"h":24}
-},
-"messages/common/ready.png":
-{
-	"frame": {"x":222,"y":64,"w":80,"h":24},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":80,"h":24},
-	"sourceSize": {"w":80,"h":24}
-},
-"messages/common/sachisoft.png":
-{
-	"frame": {"x":2,"y":20,"w":360,"h":20},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":360,"h":20},
-	"sourceSize": {"w":360,"h":20}
-},
-"messages/ja/fight.png":
-{
-	"frame": {"x":92,"y":723,"w":160,"h":160},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":160,"h":160},
-	"sourceSize": {"w":160,"h":160}
-},
-"messages/ja/game_start.png":
-{
-	"frame": {"x":304,"y":64,"w":96,"h":24},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":96,"h":24},
-	"sourceSize": {"w":96,"h":24}
-},
-"messages/ja/mark.png":
-{
-	"frame": {"x":386,"y":611,"w":88,"h":110},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":88,"h":110},
-	"sourceSize": {"w":88,"h":110}
-},
-"messages/ja/pikachu_volleyball.png":
-{
-	"frame": {"x":2,"y":530,"w":276,"h":79},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":276,"h":79},
-	"sourceSize": {"w":276,"h":79}
-},
-"messages/ja/pokemon.png":
-{
-	"frame": {"x":150,"y":90,"w":200,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":200,"h":32},
-	"sourceSize": {"w":200,"h":32}
-},
-"messages/ja/with_computer.png":
-{
-	"frame": {"x":2,"y":42,"w":120,"h":20},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":120,"h":20},
-	"sourceSize": {"w":120,"h":20}
-},
-"messages/ja/with_friend.png":
-{
-	"frame": {"x":124,"y":42,"w":120,"h":20},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":120,"h":20},
-	"sourceSize": {"w":120,"h":20}
-},
-"messages/ko/fight.png":
-{
-	"frame": {"x":254,"y":723,"w":160,"h":160},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":160,"h":160},
-	"sourceSize": {"w":160,"h":160}
-},
-"messages/ko/game_start.png":
-{
-	"frame": {"x":2,"y":90,"w":96,"h":24},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":96,"h":24},
-	"sourceSize": {"w":96,"h":24}
-},
-"messages/ko/mark.png":
-{
-	"frame": {"x":2,"y":723,"w":88,"h":110},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":88,"h":110},
-	"sourceSize": {"w":88,"h":110}
-},
-"messages/ko/pikachu_volleyball.png":
-{
-	"frame": {"x":2,"y":611,"w":276,"h":79},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":276,"h":79},
-	"sourceSize": {"w":276,"h":79}
-},
-"messages/ko/pokemon.png":
-{
-	"frame": {"x":2,"y":124,"w":200,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":200,"h":32},
-	"sourceSize": {"w":200,"h":32}
-},
-"messages/ko/with_computer.png":
-{
-	"frame": {"x":246,"y":42,"w":120,"h":20},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":120,"h":20},
-	"sourceSize": {"w":120,"h":20}
-},
-"messages/ko/with_friend.png":
-{
-	"frame": {"x":2,"y":64,"w":120,"h":20},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":120,"h":20},
-	"sourceSize": {"w":120,"h":20}
-},
-"number/number_0.png":
-{
-	"frame": {"x":204,"y":124,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_1.png":
-{
-	"frame": {"x":238,"y":124,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_2.png":
-{
-	"frame": {"x":272,"y":124,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_3.png":
-{
-	"frame": {"x":306,"y":124,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_4.png":
-{
-	"frame": {"x":340,"y":124,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_5.png":
-{
-	"frame": {"x":374,"y":124,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_6.png":
-{
-	"frame": {"x":408,"y":124,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_7.png":
-{
-	"frame": {"x":442,"y":124,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_8.png":
-{
-	"frame": {"x":2,"y":158,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"number/number_9.png":
-{
-	"frame": {"x":36,"y":158,"w":32,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
-	"sourceSize": {"w":32,"h":32}
-},
-"objects/black.png":
-{
-	"frame": {"x":2,"y":2,"w":8,"h":8},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":8,"h":8},
-	"sourceSize": {"w":8,"h":8}
-},
-"objects/cloud.png":
-{
-	"frame": {"x":100,"y":90,"w":48,"h":24},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":48,"h":24},
-	"sourceSize": {"w":48,"h":24}
-},
-"objects/ground_line.png":
-{
-	"frame": {"x":66,"y":2,"w":16,"h":16},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
-	"sourceSize": {"w":16,"h":16}
-},
-"objects/ground_line_leftmost.png":
-{
-	"frame": {"x":84,"y":2,"w":16,"h":16},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
-	"sourceSize": {"w":16,"h":16}
-},
-"objects/ground_line_rightmost.png":
-{
-	"frame": {"x":102,"y":2,"w":16,"h":16},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
-	"sourceSize": {"w":16,"h":16}
-},
-"objects/ground_red.png":
-{
-	"frame": {"x":120,"y":2,"w":16,"h":16},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
-	"sourceSize": {"w":16,"h":16}
-},
-"objects/ground_yellow.png":
-{
-	"frame": {"x":138,"y":2,"w":16,"h":16},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
-	"sourceSize": {"w":16,"h":16}
-},
-"objects/mountain.png":
-{
-	"frame": {"x":2,"y":200,"w":432,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":432,"h":64},
-	"sourceSize": {"w":432,"h":64}
-},
-"objects/net_pillar.png":
-{
-	"frame": {"x":12,"y":2,"w":8,"h":8},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":8,"h":8},
-	"sourceSize": {"w":8,"h":8}
-},
-"objects/net_pillar_top.png":
-{
-	"frame": {"x":22,"y":2,"w":8,"h":8},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":8,"h":8},
-	"sourceSize": {"w":8,"h":8}
-},
-"objects/shadow.png":
-{
-	"frame": {"x":32,"y":2,"w":32,"h":8},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":8},
-	"sourceSize": {"w":32,"h":8}
-},
-"objects/sky_blue.png":
-{
-	"frame": {"x":156,"y":2,"w":16,"h":16},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
-	"sourceSize": {"w":16,"h":16}
-},
-"objects/wave.png":
-{
-	"frame": {"x":70,"y":158,"w":16,"h":32},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":32},
-	"sourceSize": {"w":16,"h":32}
-},
-"pikachu/pikachu_0_0.png":
-{
-	"frame": {"x":2,"y":266,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_0_1.png":
-{
-	"frame": {"x":68,"y":266,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_0_2.png":
-{
-	"frame": {"x":134,"y":266,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_0_3.png":
-{
-	"frame": {"x":200,"y":266,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_0_4.png":
-{
-	"frame": {"x":266,"y":266,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_1_0.png":
-{
-	"frame": {"x":332,"y":266,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_1_1.png":
-{
-	"frame": {"x":398,"y":266,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_1_2.png":
-{
-	"frame": {"x":2,"y":332,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_1_3.png":
-{
-	"frame": {"x":68,"y":332,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_1_4.png":
-{
-	"frame": {"x":134,"y":332,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_2_0.png":
-{
-	"frame": {"x":200,"y":332,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_2_1.png":
-{
-	"frame": {"x":266,"y":332,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_2_2.png":
-{
-	"frame": {"x":332,"y":332,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_2_3.png":
-{
-	"frame": {"x":398,"y":332,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_2_4.png":
-{
-	"frame": {"x":2,"y":398,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_3_0.png":
-{
-	"frame": {"x":68,"y":398,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_3_1.png":
-{
-	"frame": {"x":134,"y":398,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_4_0.png":
-{
-	"frame": {"x":200,"y":398,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_5_0.png":
-{
-	"frame": {"x":266,"y":398,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_5_1.png":
-{
-	"frame": {"x":332,"y":398,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_5_2.png":
-{
-	"frame": {"x":398,"y":398,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_5_3.png":
-{
-	"frame": {"x":2,"y":464,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_5_4.png":
-{
-	"frame": {"x":68,"y":464,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_6_0.png":
-{
-	"frame": {"x":134,"y":464,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_6_1.png":
-{
-	"frame": {"x":200,"y":464,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_6_2.png":
-{
-	"frame": {"x":266,"y":464,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_6_3.png":
-{
-	"frame": {"x":332,"y":464,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"pikachu/pikachu_6_4.png":
-{
-	"frame": {"x":398,"y":464,"w":64,"h":64},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
-	"sourceSize": {"w":64,"h":64}
-},
-"sitting_pikachu.png":
-{
-	"frame": {"x":280,"y":611,"w":104,"h":104},
-	"rotated": false,
-	"trimmed": false,
-	"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
-	"sourceSize": {"w":104,"h":104}
-}},
-"animations": {
-	"ball/ball": ["ball/ball_0.png","ball/ball_1.png","ball/ball_2.png","ball/ball_3.png","ball/ball_4.png"],
-	"number/number": ["number/number_0.png","number/number_1.png","number/number_2.png","number/number_3.png","number/number_4.png","number/number_5.png","number/number_6.png","number/number_7.png","number/number_8.png","number/number_9.png"],
-	"pikachu/pikachu_0": ["pikachu/pikachu_0_0.png","pikachu/pikachu_0_1.png","pikachu/pikachu_0_2.png","pikachu/pikachu_0_3.png","pikachu/pikachu_0_4.png"],
-	"pikachu/pikachu_1": ["pikachu/pikachu_1_0.png","pikachu/pikachu_1_1.png","pikachu/pikachu_1_2.png","pikachu/pikachu_1_3.png","pikachu/pikachu_1_4.png"],
-	"pikachu/pikachu_2": ["pikachu/pikachu_2_0.png","pikachu/pikachu_2_1.png","pikachu/pikachu_2_2.png","pikachu/pikachu_2_3.png","pikachu/pikachu_2_4.png"],
-	"pikachu/pikachu_3": ["pikachu/pikachu_3_0.png","pikachu/pikachu_3_1.png"],
-	"pikachu/pikachu_5": ["pikachu/pikachu_5_0.png","pikachu/pikachu_5_1.png","pikachu/pikachu_5_2.png","pikachu/pikachu_5_3.png","pikachu/pikachu_5_4.png"],
-	"pikachu/pikachu_6": ["pikachu/pikachu_6_0.png","pikachu/pikachu_6_1.png","pikachu/pikachu_6_2.png","pikachu/pikachu_6_3.png","pikachu/pikachu_6_4.png"]
-},
-"meta": {
-	"app": "https://www.codeandweb.com/texturepacker",
-	"version": "1.0",
-	"image": "sprite_sheet.png",
-	"format": "RGBA8888",
-	"size": {"w":476,"h":885},
-	"scale": "1",
-	"smartupdate": "$TexturePacker:SmartUpdate:37eaeab36e11c29cadb9c763d77ccd63:4ee02ff09c4e34c8aca11301db3f8fd1:6cc8953523e0367402f95f3c9a630665$"
-}
+  "frames": {
+    "ball/ball_0.png": {
+      "frame": { "x": 88, "y": 158, "w": 40, "h": 40 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
+      "sourceSize": { "w": 40, "h": 40 }
+    },
+    "ball/ball_1.png": {
+      "frame": { "x": 130, "y": 158, "w": 40, "h": 40 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
+      "sourceSize": { "w": 40, "h": 40 }
+    },
+    "ball/ball_2.png": {
+      "frame": { "x": 172, "y": 158, "w": 40, "h": 40 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
+      "sourceSize": { "w": 40, "h": 40 }
+    },
+    "ball/ball_3.png": {
+      "frame": { "x": 214, "y": 158, "w": 40, "h": 40 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
+      "sourceSize": { "w": 40, "h": 40 }
+    },
+    "ball/ball_4.png": {
+      "frame": { "x": 256, "y": 158, "w": 40, "h": 40 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
+      "sourceSize": { "w": 40, "h": 40 }
+    },
+    "ball/ball_hyper.png": {
+      "frame": { "x": 298, "y": 158, "w": 40, "h": 40 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
+      "sourceSize": { "w": 40, "h": 40 }
+    },
+    "ball/ball_punch.png": {
+      "frame": { "x": 340, "y": 158, "w": 40, "h": 40 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
+      "sourceSize": { "w": 40, "h": 40 }
+    },
+    "ball/ball_trail.png": {
+      "frame": { "x": 382, "y": 158, "w": 40, "h": 40 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
+      "sourceSize": { "w": 40, "h": 40 }
+    },
+    "messages/common/game_end.png": {
+      "frame": { "x": 124, "y": 64, "w": 96, "h": 24 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 96, "h": 24 },
+      "sourceSize": { "w": 96, "h": 24 }
+    },
+    "messages/common/ready.png": {
+      "frame": { "x": 222, "y": 64, "w": 80, "h": 24 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 80, "h": 24 },
+      "sourceSize": { "w": 80, "h": 24 }
+    },
+    "messages/common/sachisoft.png": {
+      "frame": { "x": 2, "y": 20, "w": 360, "h": 20 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 360, "h": 20 },
+      "sourceSize": { "w": 360, "h": 20 }
+    },
+    "messages/ja/fight.png": {
+      "frame": { "x": 92, "y": 723, "w": 160, "h": 160 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 160, "h": 160 },
+      "sourceSize": { "w": 160, "h": 160 }
+    },
+    "messages/ja/game_start.png": {
+      "frame": { "x": 304, "y": 64, "w": 96, "h": 24 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 96, "h": 24 },
+      "sourceSize": { "w": 96, "h": 24 }
+    },
+    "messages/ja/mark.png": {
+      "frame": { "x": 386, "y": 611, "w": 88, "h": 110 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 88, "h": 110 },
+      "sourceSize": { "w": 88, "h": 110 }
+    },
+    "messages/ja/pikachu_volleyball.png": {
+      "frame": { "x": 2, "y": 530, "w": 276, "h": 79 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 276, "h": 79 },
+      "sourceSize": { "w": 276, "h": 79 }
+    },
+    "messages/ja/pokemon.png": {
+      "frame": { "x": 150, "y": 90, "w": 200, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 200, "h": 32 },
+      "sourceSize": { "w": 200, "h": 32 }
+    },
+    "messages/ja/with_computer.png": {
+      "frame": { "x": 2, "y": 42, "w": 120, "h": 20 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 120, "h": 20 },
+      "sourceSize": { "w": 120, "h": 20 }
+    },
+    "messages/ja/with_friend.png": {
+      "frame": { "x": 124, "y": 42, "w": 120, "h": 20 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 120, "h": 20 },
+      "sourceSize": { "w": 120, "h": 20 }
+    },
+    "messages/ko/fight.png": {
+      "frame": { "x": 254, "y": 723, "w": 160, "h": 160 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 160, "h": 160 },
+      "sourceSize": { "w": 160, "h": 160 }
+    },
+    "messages/ko/game_start.png": {
+      "frame": { "x": 2, "y": 90, "w": 96, "h": 24 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 96, "h": 24 },
+      "sourceSize": { "w": 96, "h": 24 }
+    },
+    "messages/ko/mark.png": {
+      "frame": { "x": 2, "y": 723, "w": 88, "h": 110 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 88, "h": 110 },
+      "sourceSize": { "w": 88, "h": 110 }
+    },
+    "messages/ko/pikachu_volleyball.png": {
+      "frame": { "x": 2, "y": 611, "w": 276, "h": 79 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 276, "h": 79 },
+      "sourceSize": { "w": 276, "h": 79 }
+    },
+    "messages/ko/pokemon.png": {
+      "frame": { "x": 2, "y": 124, "w": 200, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 200, "h": 32 },
+      "sourceSize": { "w": 200, "h": 32 }
+    },
+    "messages/ko/with_computer.png": {
+      "frame": { "x": 246, "y": 42, "w": 120, "h": 20 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 120, "h": 20 },
+      "sourceSize": { "w": 120, "h": 20 }
+    },
+    "messages/ko/with_friend.png": {
+      "frame": { "x": 2, "y": 64, "w": 120, "h": 20 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 120, "h": 20 },
+      "sourceSize": { "w": 120, "h": 20 }
+    },
+    "number/number_0.png": {
+      "frame": { "x": 204, "y": 124, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_1.png": {
+      "frame": { "x": 238, "y": 124, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_2.png": {
+      "frame": { "x": 272, "y": 124, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_3.png": {
+      "frame": { "x": 306, "y": 124, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_4.png": {
+      "frame": { "x": 340, "y": 124, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_5.png": {
+      "frame": { "x": 374, "y": 124, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_6.png": {
+      "frame": { "x": 408, "y": 124, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_7.png": {
+      "frame": { "x": 442, "y": 124, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_8.png": {
+      "frame": { "x": 2, "y": 158, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "number/number_9.png": {
+      "frame": { "x": 36, "y": 158, "w": 32, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+      "sourceSize": { "w": 32, "h": 32 }
+    },
+    "objects/black.png": {
+      "frame": { "x": 2, "y": 2, "w": 8, "h": 8 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 8, "h": 8 },
+      "sourceSize": { "w": 8, "h": 8 }
+    },
+    "objects/cloud.png": {
+      "frame": { "x": 100, "y": 90, "w": 48, "h": 24 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 48, "h": 24 },
+      "sourceSize": { "w": 48, "h": 24 }
+    },
+    "objects/ground_line.png": {
+      "frame": { "x": 66, "y": 2, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 }
+    },
+    "objects/ground_line_leftmost.png": {
+      "frame": { "x": 84, "y": 2, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 }
+    },
+    "objects/ground_line_rightmost.png": {
+      "frame": { "x": 102, "y": 2, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 }
+    },
+    "objects/ground_red.png": {
+      "frame": { "x": 120, "y": 2, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 }
+    },
+    "objects/ground_yellow.png": {
+      "frame": { "x": 138, "y": 2, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 }
+    },
+    "objects/mountain.png": {
+      "frame": { "x": 2, "y": 200, "w": 432, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 432, "h": 64 },
+      "sourceSize": { "w": 432, "h": 64 }
+    },
+    "objects/net_pillar.png": {
+      "frame": { "x": 12, "y": 2, "w": 8, "h": 8 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 8, "h": 8 },
+      "sourceSize": { "w": 8, "h": 8 }
+    },
+    "objects/net_pillar_top.png": {
+      "frame": { "x": 22, "y": 2, "w": 8, "h": 8 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 8, "h": 8 },
+      "sourceSize": { "w": 8, "h": 8 }
+    },
+    "objects/shadow.png": {
+      "frame": { "x": 32, "y": 2, "w": 32, "h": 8 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 8 },
+      "sourceSize": { "w": 32, "h": 8 }
+    },
+    "objects/sky_blue.png": {
+      "frame": { "x": 156, "y": 2, "w": 16, "h": 16 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
+      "sourceSize": { "w": 16, "h": 16 }
+    },
+    "objects/wave.png": {
+      "frame": { "x": 70, "y": 158, "w": 16, "h": 32 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 32 },
+      "sourceSize": { "w": 16, "h": 32 }
+    },
+    "pikachu/pikachu_0_0.png": {
+      "frame": { "x": 2, "y": 266, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_0_1.png": {
+      "frame": { "x": 68, "y": 266, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_0_2.png": {
+      "frame": { "x": 134, "y": 266, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_0_3.png": {
+      "frame": { "x": 200, "y": 266, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_0_4.png": {
+      "frame": { "x": 266, "y": 266, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_1_0.png": {
+      "frame": { "x": 332, "y": 266, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_1_1.png": {
+      "frame": { "x": 398, "y": 266, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_1_2.png": {
+      "frame": { "x": 2, "y": 332, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_1_3.png": {
+      "frame": { "x": 68, "y": 332, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_1_4.png": {
+      "frame": { "x": 134, "y": 332, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_2_0.png": {
+      "frame": { "x": 200, "y": 332, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_2_1.png": {
+      "frame": { "x": 266, "y": 332, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_2_2.png": {
+      "frame": { "x": 332, "y": 332, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_2_3.png": {
+      "frame": { "x": 398, "y": 332, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_2_4.png": {
+      "frame": { "x": 2, "y": 398, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_3_0.png": {
+      "frame": { "x": 68, "y": 398, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_3_1.png": {
+      "frame": { "x": 134, "y": 398, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_4_0.png": {
+      "frame": { "x": 200, "y": 398, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_5_0.png": {
+      "frame": { "x": 266, "y": 398, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_5_1.png": {
+      "frame": { "x": 332, "y": 398, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_5_2.png": {
+      "frame": { "x": 398, "y": 398, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_5_3.png": {
+      "frame": { "x": 2, "y": 464, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_5_4.png": {
+      "frame": { "x": 68, "y": 464, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_6_0.png": {
+      "frame": { "x": 134, "y": 464, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_6_1.png": {
+      "frame": { "x": 200, "y": 464, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_6_2.png": {
+      "frame": { "x": 266, "y": 464, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_6_3.png": {
+      "frame": { "x": 332, "y": 464, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "pikachu/pikachu_6_4.png": {
+      "frame": { "x": 398, "y": 464, "w": 64, "h": 64 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
+      "sourceSize": { "w": 64, "h": 64 }
+    },
+    "sitting_pikachu.png": {
+      "frame": { "x": 280, "y": 611, "w": 104, "h": 104 },
+      "rotated": false,
+      "trimmed": false,
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 104, "h": 104 },
+      "sourceSize": { "w": 104, "h": 104 }
+    }
+  },
+  "animations": {
+    "ball/ball": [
+      "ball/ball_0.png",
+      "ball/ball_1.png",
+      "ball/ball_2.png",
+      "ball/ball_3.png",
+      "ball/ball_4.png"
+    ],
+    "number/number": [
+      "number/number_0.png",
+      "number/number_1.png",
+      "number/number_2.png",
+      "number/number_3.png",
+      "number/number_4.png",
+      "number/number_5.png",
+      "number/number_6.png",
+      "number/number_7.png",
+      "number/number_8.png",
+      "number/number_9.png"
+    ],
+    "pikachu/pikachu_0": [
+      "pikachu/pikachu_0_0.png",
+      "pikachu/pikachu_0_1.png",
+      "pikachu/pikachu_0_2.png",
+      "pikachu/pikachu_0_3.png",
+      "pikachu/pikachu_0_4.png"
+    ],
+    "pikachu/pikachu_1": [
+      "pikachu/pikachu_1_0.png",
+      "pikachu/pikachu_1_1.png",
+      "pikachu/pikachu_1_2.png",
+      "pikachu/pikachu_1_3.png",
+      "pikachu/pikachu_1_4.png"
+    ],
+    "pikachu/pikachu_2": [
+      "pikachu/pikachu_2_0.png",
+      "pikachu/pikachu_2_1.png",
+      "pikachu/pikachu_2_2.png",
+      "pikachu/pikachu_2_3.png",
+      "pikachu/pikachu_2_4.png"
+    ],
+    "pikachu/pikachu_3": ["pikachu/pikachu_3_0.png", "pikachu/pikachu_3_1.png"],
+    "pikachu/pikachu_5": [
+      "pikachu/pikachu_5_0.png",
+      "pikachu/pikachu_5_1.png",
+      "pikachu/pikachu_5_2.png",
+      "pikachu/pikachu_5_3.png",
+      "pikachu/pikachu_5_4.png"
+    ],
+    "pikachu/pikachu_6": [
+      "pikachu/pikachu_6_0.png",
+      "pikachu/pikachu_6_1.png",
+      "pikachu/pikachu_6_2.png",
+      "pikachu/pikachu_6_3.png",
+      "pikachu/pikachu_6_4.png"
+    ]
+  },
+  "meta": {
+    "app": "https://www.codeandweb.com/texturepacker",
+    "version": "1.0",
+    "image": "sprite_sheet.png",
+    "format": "RGBA8888",
+    "size": { "w": 476, "h": 885 },
+    "scale": "1",
+    "smartupdate": "$TexturePacker:SmartUpdate:37eaeab36e11c29cadb9c763d77ccd63:4ee02ff09c4e34c8aca11301db3f8fd1:6cc8953523e0367402f95f3c9a630665$"
+  }
 }

--- a/src/resources/assets/images/sprite_sheet.json
+++ b/src/resources/assets/images/sprite_sheet.json
@@ -1,609 +1,638 @@
+{"frames": {
+
+"ball/ball_0.png":
 {
-  "frames": {
-    "ball/ball_0.png": {
-      "frame": { "x": 88, "y": 158, "w": 40, "h": 40 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
-      "sourceSize": { "w": 40, "h": 40 }
-    },
-    "ball/ball_1.png": {
-      "frame": { "x": 130, "y": 158, "w": 40, "h": 40 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
-      "sourceSize": { "w": 40, "h": 40 }
-    },
-    "ball/ball_2.png": {
-      "frame": { "x": 172, "y": 158, "w": 40, "h": 40 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
-      "sourceSize": { "w": 40, "h": 40 }
-    },
-    "ball/ball_3.png": {
-      "frame": { "x": 214, "y": 158, "w": 40, "h": 40 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
-      "sourceSize": { "w": 40, "h": 40 }
-    },
-    "ball/ball_4.png": {
-      "frame": { "x": 256, "y": 158, "w": 40, "h": 40 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
-      "sourceSize": { "w": 40, "h": 40 }
-    },
-    "ball/ball_hyper.png": {
-      "frame": { "x": 298, "y": 158, "w": 40, "h": 40 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
-      "sourceSize": { "w": 40, "h": 40 }
-    },
-    "ball/ball_punch.png": {
-      "frame": { "x": 340, "y": 158, "w": 40, "h": 40 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
-      "sourceSize": { "w": 40, "h": 40 }
-    },
-    "ball/ball_trail.png": {
-      "frame": { "x": 382, "y": 158, "w": 40, "h": 40 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 40, "h": 40 },
-      "sourceSize": { "w": 40, "h": 40 }
-    },
-    "messages/common/game_end.png": {
-      "frame": { "x": 124, "y": 64, "w": 96, "h": 24 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 96, "h": 24 },
-      "sourceSize": { "w": 96, "h": 24 }
-    },
-    "messages/common/ready.png": {
-      "frame": { "x": 222, "y": 64, "w": 80, "h": 24 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 80, "h": 24 },
-      "sourceSize": { "w": 80, "h": 24 }
-    },
-    "messages/common/sachisoft.png": {
-      "frame": { "x": 2, "y": 20, "w": 360, "h": 20 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 360, "h": 20 },
-      "sourceSize": { "w": 360, "h": 20 }
-    },
-    "messages/ja/fight.png": {
-      "frame": { "x": 92, "y": 723, "w": 160, "h": 160 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 160, "h": 160 },
-      "sourceSize": { "w": 160, "h": 160 }
-    },
-    "messages/ja/game_start.png": {
-      "frame": { "x": 304, "y": 64, "w": 96, "h": 24 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 96, "h": 24 },
-      "sourceSize": { "w": 96, "h": 24 }
-    },
-    "messages/ja/mark.png": {
-      "frame": { "x": 386, "y": 611, "w": 88, "h": 110 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 88, "h": 110 },
-      "sourceSize": { "w": 88, "h": 110 }
-    },
-    "messages/ja/pikachu_volleyball.png": {
-      "frame": { "x": 2, "y": 530, "w": 276, "h": 79 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 276, "h": 79 },
-      "sourceSize": { "w": 276, "h": 79 }
-    },
-    "messages/ja/pokemon.png": {
-      "frame": { "x": 150, "y": 90, "w": 200, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 200, "h": 32 },
-      "sourceSize": { "w": 200, "h": 32 }
-    },
-    "messages/ja/with_computer.png": {
-      "frame": { "x": 2, "y": 42, "w": 120, "h": 20 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 120, "h": 20 },
-      "sourceSize": { "w": 120, "h": 20 }
-    },
-    "messages/ja/with_friend.png": {
-      "frame": { "x": 124, "y": 42, "w": 120, "h": 20 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 120, "h": 20 },
-      "sourceSize": { "w": 120, "h": 20 }
-    },
-    "messages/ko/fight.png": {
-      "frame": { "x": 254, "y": 723, "w": 160, "h": 160 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 160, "h": 160 },
-      "sourceSize": { "w": 160, "h": 160 }
-    },
-    "messages/ko/game_start.png": {
-      "frame": { "x": 2, "y": 90, "w": 96, "h": 24 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 96, "h": 24 },
-      "sourceSize": { "w": 96, "h": 24 }
-    },
-    "messages/ko/mark.png": {
-      "frame": { "x": 2, "y": 723, "w": 88, "h": 110 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 88, "h": 110 },
-      "sourceSize": { "w": 88, "h": 110 }
-    },
-    "messages/ko/pikachu_volleyball.png": {
-      "frame": { "x": 2, "y": 611, "w": 276, "h": 79 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 276, "h": 79 },
-      "sourceSize": { "w": 276, "h": 79 }
-    },
-    "messages/ko/pokemon.png": {
-      "frame": { "x": 2, "y": 124, "w": 200, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 200, "h": 32 },
-      "sourceSize": { "w": 200, "h": 32 }
-    },
-    "messages/ko/with_computer.png": {
-      "frame": { "x": 246, "y": 42, "w": 120, "h": 20 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 120, "h": 20 },
-      "sourceSize": { "w": 120, "h": 20 }
-    },
-    "messages/ko/with_friend.png": {
-      "frame": { "x": 2, "y": 64, "w": 120, "h": 20 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 120, "h": 20 },
-      "sourceSize": { "w": 120, "h": 20 }
-    },
-    "number/number_0.png": {
-      "frame": { "x": 204, "y": 124, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_1.png": {
-      "frame": { "x": 238, "y": 124, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_2.png": {
-      "frame": { "x": 272, "y": 124, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_3.png": {
-      "frame": { "x": 306, "y": 124, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_4.png": {
-      "frame": { "x": 340, "y": 124, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_5.png": {
-      "frame": { "x": 374, "y": 124, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_6.png": {
-      "frame": { "x": 408, "y": 124, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_7.png": {
-      "frame": { "x": 442, "y": 124, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_8.png": {
-      "frame": { "x": 2, "y": 158, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "number/number_9.png": {
-      "frame": { "x": 36, "y": 158, "w": 32, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
-      "sourceSize": { "w": 32, "h": 32 }
-    },
-    "objects/black.png": {
-      "frame": { "x": 2, "y": 2, "w": 8, "h": 8 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 8, "h": 8 },
-      "sourceSize": { "w": 8, "h": 8 }
-    },
-    "objects/cloud.png": {
-      "frame": { "x": 100, "y": 90, "w": 48, "h": 24 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 48, "h": 24 },
-      "sourceSize": { "w": 48, "h": 24 }
-    },
-    "objects/ground_line.png": {
-      "frame": { "x": 66, "y": 2, "w": 16, "h": 16 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
-      "sourceSize": { "w": 16, "h": 16 }
-    },
-    "objects/ground_line_leftmost.png": {
-      "frame": { "x": 84, "y": 2, "w": 16, "h": 16 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
-      "sourceSize": { "w": 16, "h": 16 }
-    },
-    "objects/ground_line_rightmost.png": {
-      "frame": { "x": 102, "y": 2, "w": 16, "h": 16 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
-      "sourceSize": { "w": 16, "h": 16 }
-    },
-    "objects/ground_red.png": {
-      "frame": { "x": 120, "y": 2, "w": 16, "h": 16 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
-      "sourceSize": { "w": 16, "h": 16 }
-    },
-    "objects/ground_yellow.png": {
-      "frame": { "x": 138, "y": 2, "w": 16, "h": 16 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
-      "sourceSize": { "w": 16, "h": 16 }
-    },
-    "objects/mountain.png": {
-      "frame": { "x": 2, "y": 200, "w": 432, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 432, "h": 64 },
-      "sourceSize": { "w": 432, "h": 64 }
-    },
-    "objects/net_pillar.png": {
-      "frame": { "x": 12, "y": 2, "w": 8, "h": 8 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 8, "h": 8 },
-      "sourceSize": { "w": 8, "h": 8 }
-    },
-    "objects/net_pillar_top.png": {
-      "frame": { "x": 22, "y": 2, "w": 8, "h": 8 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 8, "h": 8 },
-      "sourceSize": { "w": 8, "h": 8 }
-    },
-    "objects/shadow.png": {
-      "frame": { "x": 32, "y": 2, "w": 32, "h": 8 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 8 },
-      "sourceSize": { "w": 32, "h": 8 }
-    },
-    "objects/sky_blue.png": {
-      "frame": { "x": 156, "y": 2, "w": 16, "h": 16 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 16 },
-      "sourceSize": { "w": 16, "h": 16 }
-    },
-    "objects/wave.png": {
-      "frame": { "x": 70, "y": 158, "w": 16, "h": 32 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 16, "h": 32 },
-      "sourceSize": { "w": 16, "h": 32 }
-    },
-    "pikachu/pikachu_0_0.png": {
-      "frame": { "x": 2, "y": 266, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_0_1.png": {
-      "frame": { "x": 68, "y": 266, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_0_2.png": {
-      "frame": { "x": 134, "y": 266, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_0_3.png": {
-      "frame": { "x": 200, "y": 266, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_0_4.png": {
-      "frame": { "x": 266, "y": 266, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_1_0.png": {
-      "frame": { "x": 332, "y": 266, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_1_1.png": {
-      "frame": { "x": 398, "y": 266, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_1_2.png": {
-      "frame": { "x": 2, "y": 332, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_1_3.png": {
-      "frame": { "x": 68, "y": 332, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_1_4.png": {
-      "frame": { "x": 134, "y": 332, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_2_0.png": {
-      "frame": { "x": 200, "y": 332, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_2_1.png": {
-      "frame": { "x": 266, "y": 332, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_2_2.png": {
-      "frame": { "x": 332, "y": 332, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_2_3.png": {
-      "frame": { "x": 398, "y": 332, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_2_4.png": {
-      "frame": { "x": 2, "y": 398, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_3_0.png": {
-      "frame": { "x": 68, "y": 398, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_3_1.png": {
-      "frame": { "x": 134, "y": 398, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_4_0.png": {
-      "frame": { "x": 200, "y": 398, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_5_0.png": {
-      "frame": { "x": 266, "y": 398, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_5_1.png": {
-      "frame": { "x": 332, "y": 398, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_5_2.png": {
-      "frame": { "x": 398, "y": 398, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_5_3.png": {
-      "frame": { "x": 2, "y": 464, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_5_4.png": {
-      "frame": { "x": 68, "y": 464, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_6_0.png": {
-      "frame": { "x": 134, "y": 464, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_6_1.png": {
-      "frame": { "x": 200, "y": 464, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_6_2.png": {
-      "frame": { "x": 266, "y": 464, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_6_3.png": {
-      "frame": { "x": 332, "y": 464, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "pikachu/pikachu_6_4.png": {
-      "frame": { "x": 398, "y": 464, "w": 64, "h": 64 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 64 },
-      "sourceSize": { "w": 64, "h": 64 }
-    },
-    "sitting_pikachu.png": {
-      "frame": { "x": 280, "y": 611, "w": 104, "h": 104 },
-      "rotated": false,
-      "trimmed": false,
-      "spriteSourceSize": { "x": 0, "y": 0, "w": 104, "h": 104 },
-      "sourceSize": { "w": 104, "h": 104 }
-    }
-  },
-  "animations": {
-    "ball/ball": [
-      "ball/ball_0.png",
-      "ball/ball_1.png",
-      "ball/ball_2.png",
-      "ball/ball_3.png",
-      "ball/ball_4.png"
-    ],
-    "number/number": [
-      "number/number_0.png",
-      "number/number_1.png",
-      "number/number_2.png",
-      "number/number_3.png",
-      "number/number_4.png",
-      "number/number_5.png",
-      "number/number_6.png",
-      "number/number_7.png",
-      "number/number_8.png",
-      "number/number_9.png"
-    ],
-    "pikachu/pikachu_0": [
-      "pikachu/pikachu_0_0.png",
-      "pikachu/pikachu_0_1.png",
-      "pikachu/pikachu_0_2.png",
-      "pikachu/pikachu_0_3.png",
-      "pikachu/pikachu_0_4.png"
-    ],
-    "pikachu/pikachu_1": [
-      "pikachu/pikachu_1_0.png",
-      "pikachu/pikachu_1_1.png",
-      "pikachu/pikachu_1_2.png",
-      "pikachu/pikachu_1_3.png",
-      "pikachu/pikachu_1_4.png"
-    ],
-    "pikachu/pikachu_2": [
-      "pikachu/pikachu_2_0.png",
-      "pikachu/pikachu_2_1.png",
-      "pikachu/pikachu_2_2.png",
-      "pikachu/pikachu_2_3.png",
-      "pikachu/pikachu_2_4.png"
-    ],
-    "pikachu/pikachu_3": ["pikachu/pikachu_3_0.png", "pikachu/pikachu_3_1.png"],
-    "pikachu/pikachu_5": [
-      "pikachu/pikachu_5_0.png",
-      "pikachu/pikachu_5_1.png",
-      "pikachu/pikachu_5_2.png",
-      "pikachu/pikachu_5_3.png",
-      "pikachu/pikachu_5_4.png"
-    ],
-    "pikachu/pikachu_6": [
-      "pikachu/pikachu_6_0.png",
-      "pikachu/pikachu_6_1.png",
-      "pikachu/pikachu_6_2.png",
-      "pikachu/pikachu_6_3.png",
-      "pikachu/pikachu_6_4.png"
-    ]
-  },
-  "meta": {
-    "app": "https://www.codeandweb.com/texturepacker",
-    "version": "1.0",
-    "image": "sprite_sheet.png",
-    "format": "RGBA8888",
-    "size": { "w": 476, "h": 885 },
-    "scale": "1",
-    "smartupdate": "$TexturePacker:SmartUpdate:37eaeab36e11c29cadb9c763d77ccd63:4ee02ff09c4e34c8aca11301db3f8fd1:6cc8953523e0367402f95f3c9a630665$"
-  }
+	"frame": {"x":88,"y":158,"w":40,"h":40},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
+	"sourceSize": {"w":40,"h":40}
+},
+"ball/ball_1.png":
+{
+	"frame": {"x":130,"y":158,"w":40,"h":40},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
+	"sourceSize": {"w":40,"h":40}
+},
+"ball/ball_2.png":
+{
+	"frame": {"x":172,"y":158,"w":40,"h":40},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
+	"sourceSize": {"w":40,"h":40}
+},
+"ball/ball_3.png":
+{
+	"frame": {"x":214,"y":158,"w":40,"h":40},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
+	"sourceSize": {"w":40,"h":40}
+},
+"ball/ball_4.png":
+{
+	"frame": {"x":256,"y":158,"w":40,"h":40},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
+	"sourceSize": {"w":40,"h":40}
+},
+"ball/ball_hyper.png":
+{
+	"frame": {"x":298,"y":158,"w":40,"h":40},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
+	"sourceSize": {"w":40,"h":40}
+},
+"ball/ball_punch.png":
+{
+	"frame": {"x":340,"y":158,"w":40,"h":40},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
+	"sourceSize": {"w":40,"h":40}
+},
+"ball/ball_trail.png":
+{
+	"frame": {"x":382,"y":158,"w":40,"h":40},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":40,"h":40},
+	"sourceSize": {"w":40,"h":40}
+},
+"messages/common/game_end.png":
+{
+	"frame": {"x":124,"y":64,"w":96,"h":24},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":96,"h":24},
+	"sourceSize": {"w":96,"h":24}
+},
+"messages/common/ready.png":
+{
+	"frame": {"x":222,"y":64,"w":80,"h":24},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":80,"h":24},
+	"sourceSize": {"w":80,"h":24}
+},
+"messages/common/sachisoft.png":
+{
+	"frame": {"x":2,"y":20,"w":360,"h":20},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":360,"h":20},
+	"sourceSize": {"w":360,"h":20}
+},
+"messages/ja/fight.png":
+{
+	"frame": {"x":92,"y":723,"w":160,"h":160},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":160,"h":160},
+	"sourceSize": {"w":160,"h":160}
+},
+"messages/ja/game_start.png":
+{
+	"frame": {"x":304,"y":64,"w":96,"h":24},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":96,"h":24},
+	"sourceSize": {"w":96,"h":24}
+},
+"messages/ja/mark.png":
+{
+	"frame": {"x":386,"y":611,"w":88,"h":110},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":88,"h":110},
+	"sourceSize": {"w":88,"h":110}
+},
+"messages/ja/pikachu_volleyball.png":
+{
+	"frame": {"x":2,"y":530,"w":276,"h":79},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":276,"h":79},
+	"sourceSize": {"w":276,"h":79}
+},
+"messages/ja/pokemon.png":
+{
+	"frame": {"x":150,"y":90,"w":200,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":200,"h":32},
+	"sourceSize": {"w":200,"h":32}
+},
+"messages/ja/with_computer.png":
+{
+	"frame": {"x":2,"y":42,"w":120,"h":20},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":120,"h":20},
+	"sourceSize": {"w":120,"h":20}
+},
+"messages/ja/with_friend.png":
+{
+	"frame": {"x":124,"y":42,"w":120,"h":20},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":120,"h":20},
+	"sourceSize": {"w":120,"h":20}
+},
+"messages/ko/fight.png":
+{
+	"frame": {"x":254,"y":723,"w":160,"h":160},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":160,"h":160},
+	"sourceSize": {"w":160,"h":160}
+},
+"messages/ko/game_start.png":
+{
+	"frame": {"x":2,"y":90,"w":96,"h":24},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":96,"h":24},
+	"sourceSize": {"w":96,"h":24}
+},
+"messages/ko/mark.png":
+{
+	"frame": {"x":2,"y":723,"w":88,"h":110},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":88,"h":110},
+	"sourceSize": {"w":88,"h":110}
+},
+"messages/ko/pikachu_volleyball.png":
+{
+	"frame": {"x":2,"y":611,"w":276,"h":79},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":276,"h":79},
+	"sourceSize": {"w":276,"h":79}
+},
+"messages/ko/pokemon.png":
+{
+	"frame": {"x":2,"y":124,"w":200,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":200,"h":32},
+	"sourceSize": {"w":200,"h":32}
+},
+"messages/ko/with_computer.png":
+{
+	"frame": {"x":246,"y":42,"w":120,"h":20},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":120,"h":20},
+	"sourceSize": {"w":120,"h":20}
+},
+"messages/ko/with_friend.png":
+{
+	"frame": {"x":2,"y":64,"w":120,"h":20},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":120,"h":20},
+	"sourceSize": {"w":120,"h":20}
+},
+"number/number_0.png":
+{
+	"frame": {"x":204,"y":124,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_1.png":
+{
+	"frame": {"x":238,"y":124,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_2.png":
+{
+	"frame": {"x":272,"y":124,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_3.png":
+{
+	"frame": {"x":306,"y":124,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_4.png":
+{
+	"frame": {"x":340,"y":124,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_5.png":
+{
+	"frame": {"x":374,"y":124,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_6.png":
+{
+	"frame": {"x":408,"y":124,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_7.png":
+{
+	"frame": {"x":442,"y":124,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_8.png":
+{
+	"frame": {"x":2,"y":158,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"number/number_9.png":
+{
+	"frame": {"x":36,"y":158,"w":32,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":32},
+	"sourceSize": {"w":32,"h":32}
+},
+"objects/black.png":
+{
+	"frame": {"x":2,"y":2,"w":8,"h":8},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":8,"h":8},
+	"sourceSize": {"w":8,"h":8}
+},
+"objects/cloud.png":
+{
+	"frame": {"x":100,"y":90,"w":48,"h":24},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":48,"h":24},
+	"sourceSize": {"w":48,"h":24}
+},
+"objects/ground_line.png":
+{
+	"frame": {"x":66,"y":2,"w":16,"h":16},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
+	"sourceSize": {"w":16,"h":16}
+},
+"objects/ground_line_leftmost.png":
+{
+	"frame": {"x":84,"y":2,"w":16,"h":16},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
+	"sourceSize": {"w":16,"h":16}
+},
+"objects/ground_line_rightmost.png":
+{
+	"frame": {"x":102,"y":2,"w":16,"h":16},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
+	"sourceSize": {"w":16,"h":16}
+},
+"objects/ground_red.png":
+{
+	"frame": {"x":120,"y":2,"w":16,"h":16},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
+	"sourceSize": {"w":16,"h":16}
+},
+"objects/ground_yellow.png":
+{
+	"frame": {"x":138,"y":2,"w":16,"h":16},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
+	"sourceSize": {"w":16,"h":16}
+},
+"objects/mountain.png":
+{
+	"frame": {"x":2,"y":200,"w":432,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":432,"h":64},
+	"sourceSize": {"w":432,"h":64}
+},
+"objects/net_pillar.png":
+{
+	"frame": {"x":12,"y":2,"w":8,"h":8},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":8,"h":8},
+	"sourceSize": {"w":8,"h":8}
+},
+"objects/net_pillar_top.png":
+{
+	"frame": {"x":22,"y":2,"w":8,"h":8},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":8,"h":8},
+	"sourceSize": {"w":8,"h":8}
+},
+"objects/shadow.png":
+{
+	"frame": {"x":32,"y":2,"w":32,"h":8},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":32,"h":8},
+	"sourceSize": {"w":32,"h":8}
+},
+"objects/sky_blue.png":
+{
+	"frame": {"x":156,"y":2,"w":16,"h":16},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":16},
+	"sourceSize": {"w":16,"h":16}
+},
+"objects/wave.png":
+{
+	"frame": {"x":70,"y":158,"w":16,"h":32},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":16,"h":32},
+	"sourceSize": {"w":16,"h":32}
+},
+"pikachu/pikachu_0_0.png":
+{
+	"frame": {"x":2,"y":266,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_0_1.png":
+{
+	"frame": {"x":68,"y":266,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_0_2.png":
+{
+	"frame": {"x":134,"y":266,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_0_3.png":
+{
+	"frame": {"x":200,"y":266,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_0_4.png":
+{
+	"frame": {"x":266,"y":266,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_1_0.png":
+{
+	"frame": {"x":332,"y":266,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_1_1.png":
+{
+	"frame": {"x":398,"y":266,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_1_2.png":
+{
+	"frame": {"x":2,"y":332,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_1_3.png":
+{
+	"frame": {"x":68,"y":332,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_1_4.png":
+{
+	"frame": {"x":134,"y":332,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_2_0.png":
+{
+	"frame": {"x":200,"y":332,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_2_1.png":
+{
+	"frame": {"x":266,"y":332,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_2_2.png":
+{
+	"frame": {"x":332,"y":332,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_2_3.png":
+{
+	"frame": {"x":398,"y":332,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_2_4.png":
+{
+	"frame": {"x":2,"y":398,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_3_0.png":
+{
+	"frame": {"x":68,"y":398,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_3_1.png":
+{
+	"frame": {"x":134,"y":398,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_4_0.png":
+{
+	"frame": {"x":200,"y":398,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_5_0.png":
+{
+	"frame": {"x":266,"y":398,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_5_1.png":
+{
+	"frame": {"x":332,"y":398,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_5_2.png":
+{
+	"frame": {"x":398,"y":398,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_5_3.png":
+{
+	"frame": {"x":2,"y":464,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_5_4.png":
+{
+	"frame": {"x":68,"y":464,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_6_0.png":
+{
+	"frame": {"x":134,"y":464,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_6_1.png":
+{
+	"frame": {"x":200,"y":464,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_6_2.png":
+{
+	"frame": {"x":266,"y":464,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_6_3.png":
+{
+	"frame": {"x":332,"y":464,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"pikachu/pikachu_6_4.png":
+{
+	"frame": {"x":398,"y":464,"w":64,"h":64},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":64,"h":64},
+	"sourceSize": {"w":64,"h":64}
+},
+"sitting_pikachu.png":
+{
+	"frame": {"x":280,"y":611,"w":104,"h":104},
+	"rotated": false,
+	"trimmed": false,
+	"spriteSourceSize": {"x":0,"y":0,"w":104,"h":104},
+	"sourceSize": {"w":104,"h":104}
+}},
+"animations": {
+	"ball/ball": ["ball/ball_0.png","ball/ball_1.png","ball/ball_2.png","ball/ball_3.png","ball/ball_4.png"],
+	"number/number": ["number/number_0.png","number/number_1.png","number/number_2.png","number/number_3.png","number/number_4.png","number/number_5.png","number/number_6.png","number/number_7.png","number/number_8.png","number/number_9.png"],
+	"pikachu/pikachu_0": ["pikachu/pikachu_0_0.png","pikachu/pikachu_0_1.png","pikachu/pikachu_0_2.png","pikachu/pikachu_0_3.png","pikachu/pikachu_0_4.png"],
+	"pikachu/pikachu_1": ["pikachu/pikachu_1_0.png","pikachu/pikachu_1_1.png","pikachu/pikachu_1_2.png","pikachu/pikachu_1_3.png","pikachu/pikachu_1_4.png"],
+	"pikachu/pikachu_2": ["pikachu/pikachu_2_0.png","pikachu/pikachu_2_1.png","pikachu/pikachu_2_2.png","pikachu/pikachu_2_3.png","pikachu/pikachu_2_4.png"],
+	"pikachu/pikachu_3": ["pikachu/pikachu_3_0.png","pikachu/pikachu_3_1.png"],
+	"pikachu/pikachu_5": ["pikachu/pikachu_5_0.png","pikachu/pikachu_5_1.png","pikachu/pikachu_5_2.png","pikachu/pikachu_5_3.png","pikachu/pikachu_5_4.png"],
+	"pikachu/pikachu_6": ["pikachu/pikachu_6_0.png","pikachu/pikachu_6_1.png","pikachu/pikachu_6_2.png","pikachu/pikachu_6_3.png","pikachu/pikachu_6_4.png"]
+},
+"meta": {
+	"app": "https://www.codeandweb.com/texturepacker",
+	"version": "1.0",
+	"image": "sprite_sheet.png",
+	"format": "RGBA8888",
+	"size": {"w":476,"h":885},
+	"scale": "1",
+	"smartupdate": "$TexturePacker:SmartUpdate:37eaeab36e11c29cadb9c763d77ccd63:4ee02ff09c4e34c8aca11301db3f8fd1:6cc8953523e0367402f95f3c9a630665$"
+}
 }

--- a/src/resources/js/data_channel/data_channel.js
+++ b/src/resources/js/data_channel/data_channel.js
@@ -173,7 +173,11 @@ export async function createRoom(roomIdToCreate) {
   roomRef = doc(db, 'rooms', roomId);
 
   if (channel.additionalIceServerUrl != null) {
-    rtcConfiguration.iceServers.push({ urls: [channel.additionalIceServerUrl], username: channel.additionalIceServerUser, credential: channel.additionalIceServerPass })
+    rtcConfiguration.iceServers.push({
+      urls: [channel.additionalIceServerUrl],
+      username: channel.additionalIceServerUser,
+      credential: channel.additionalIceServerPass,
+    });
   }
 
   console.log('Create PeerConnection with configuration: ', rtcConfiguration);
@@ -285,7 +289,11 @@ export async function joinRoom(roomIdToJoin) {
   }
 
   if (channel.additionalIceServer != null) {
-    rtcConfiguration.iceServers.push({ urls: [channel.additionalIceServerUrl], username: channel.additionalIceServerUser, credential: channel.additionalIceServerPass })
+    rtcConfiguration.iceServers.push({
+      urls: [channel.additionalIceServerUrl],
+      username: channel.additionalIceServerUser,
+      credential: channel.additionalIceServerPass,
+    });
   }
 
   console.log('Create PeerConnection with configuration: ', rtcConfiguration);

--- a/src/resources/js/data_channel/data_channel.js
+++ b/src/resources/js/data_channel/data_channel.js
@@ -712,9 +712,9 @@ function respondToPingTest(data) {
   } else if (dataView.getInt8(0) === -2) {
     pingTestManager.pingMesurementArray.push(
       Date.now() -
-      pingTestManager.pingSentTimeArray[
-      pingTestManager.receivedPingResponseNumber
-      ]
+        pingTestManager.pingSentTimeArray[
+          pingTestManager.receivedPingResponseNumber
+        ]
     );
     pingTestManager.receivedPingResponseNumber++;
   }

--- a/src/resources/js/data_channel/data_channel.js
+++ b/src/resources/js/data_channel/data_channel.js
@@ -86,6 +86,9 @@ export const channel = {
   amIPlayer2: null, // set from pikavolley_online.js
   isQuickMatch: null, // set from ui_online.js
   myNickname: '', // set from ui_online.js
+  additionalIceServerUrl: null, // set from ui_online.js
+  additionalIceServerUser: null, // set from ui_online.js
+  additionalIceServerPass: null, // set from ui_online.js
   peerNickname: '',
   myPartialPublicIP: '*.*.*.*',
   peerPartialPublicIP: '*.*.*.*',
@@ -168,6 +171,10 @@ export async function createRoom(roomIdToCreate) {
 
   const db = getFirestore(firebaseApp);
   roomRef = doc(db, 'rooms', roomId);
+
+  if (channel.additionalIceServerUrl != null) {
+    rtcConfiguration.iceServers.push({ urls: [channel.additionalIceServerUrl], username: channel.additionalIceServerUser, credential: channel.additionalIceServerPass })
+  }
 
   console.log('Create PeerConnection with configuration: ', rtcConfiguration);
   peerConnection = new RTCPeerConnection(rtcConfiguration);
@@ -275,6 +282,10 @@ export async function joinRoom(roomIdToJoin) {
     console.log('The room is already joined by someone else');
     printSomeoneElseAlreadyJoinedRoomMessage();
     return false;
+  }
+
+  if (channel.additionalIceServer != null) {
+    rtcConfiguration.iceServers.push({ urls: [channel.additionalIceServerUrl], username: channel.additionalIceServerUser, credential: channel.additionalIceServerPass })
   }
 
   console.log('Create PeerConnection with configuration: ', rtcConfiguration);
@@ -701,9 +712,9 @@ function respondToPingTest(data) {
   } else if (dataView.getInt8(0) === -2) {
     pingTestManager.pingMesurementArray.push(
       Date.now() -
-        pingTestManager.pingSentTimeArray[
-          pingTestManager.receivedPingResponseNumber
-        ]
+      pingTestManager.pingSentTimeArray[
+      pingTestManager.receivedPingResponseNumber
+      ]
     );
     pingTestManager.receivedPingResponseNumber++;
   }

--- a/src/resources/js/data_channel/data_channel.js
+++ b/src/resources/js/data_channel/data_channel.js
@@ -173,11 +173,7 @@ export async function createRoom(roomIdToCreate) {
   roomRef = doc(db, 'rooms', roomId);
 
   if (channel.additionalIceServerUrl != null) {
-    rtcConfiguration.iceServers.push({
-      urls: [channel.additionalIceServerUrl],
-      username: channel.additionalIceServerUser,
-      credential: channel.additionalIceServerPass,
-    });
+    rtcConfiguration.iceServers.push({ urls: [channel.additionalIceServerUrl], username: channel.additionalIceServerUser, credential: channel.additionalIceServerPass })
   }
 
   console.log('Create PeerConnection with configuration: ', rtcConfiguration);
@@ -289,11 +285,7 @@ export async function joinRoom(roomIdToJoin) {
   }
 
   if (channel.additionalIceServer != null) {
-    rtcConfiguration.iceServers.push({
-      urls: [channel.additionalIceServerUrl],
-      username: channel.additionalIceServerUser,
-      credential: channel.additionalIceServerPass,
-    });
+    rtcConfiguration.iceServers.push({ urls: [channel.additionalIceServerUrl], username: channel.additionalIceServerUser, credential: channel.additionalIceServerPass })
   }
 
   console.log('Create PeerConnection with configuration: ', rtcConfiguration);

--- a/src/resources/js/ui_online.js
+++ b/src/resources/js/ui_online.js
@@ -238,24 +238,25 @@ export function setUpUI() {
   const iceServerInputUrlElem = document.getElementById('ice-server-url-input');
   iceServerInputUrlElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerUrl = event.target.value
-      .trim();
+    channel.additionalIceServerUrl = event.target.value.trim();
     // @ts-ignore
     iceServerInputUrlElem.value = channel.additionalIceServerUrl;
   });
-  const iceServerInputUserElem = document.getElementById('ice-server-user-input');
+  const iceServerInputUserElem = document.getElementById(
+    'ice-server-user-input'
+  );
   iceServerInputUserElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerUser = event.target.value
-      .trim();
+    channel.additionalIceServerUser = event.target.value.trim();
     // @ts-ignore
     iceServerInputUserElem.value = channel.additionalIceServerUser;
   });
-  const iceServerInputPassElem = document.getElementById('ice-server-pass-input');
+  const iceServerInputPassElem = document.getElementById(
+    'ice-server-pass-input'
+  );
   iceServerInputPassElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerPass = event.target.value
-      .trim();
+    channel.additionalIceServerPass = event.target.value.trim();
     // @ts-ignore
     iceServerInputPassElem.value = channel.additionalIceServerPass;
   });

--- a/src/resources/js/ui_online.js
+++ b/src/resources/js/ui_online.js
@@ -238,25 +238,24 @@ export function setUpUI() {
   const iceServerInputUrlElem = document.getElementById('ice-server-url-input');
   iceServerInputUrlElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerUrl = event.target.value.trim();
+    channel.additionalIceServerUrl = event.target.value
+      .trim();
     // @ts-ignore
     iceServerInputUrlElem.value = channel.additionalIceServerUrl;
   });
-  const iceServerInputUserElem = document.getElementById(
-    'ice-server-username-input'
-  );
+  const iceServerInputUserElem = document.getElementById('ice-server-user-input');
   iceServerInputUserElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerUser = event.target.value.trim();
+    channel.additionalIceServerUser = event.target.value
+      .trim();
     // @ts-ignore
     iceServerInputUserElem.value = channel.additionalIceServerUser;
   });
-  const iceServerInputPassElem = document.getElementById(
-    'ice-server-credential-input'
-  );
+  const iceServerInputPassElem = document.getElementById('ice-server-pass-input');
   iceServerInputPassElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerPass = event.target.value.trim();
+    channel.additionalIceServerPass = event.target.value
+      .trim();
     // @ts-ignore
     iceServerInputPassElem.value = channel.additionalIceServerPass;
   });

--- a/src/resources/js/ui_online.js
+++ b/src/resources/js/ui_online.js
@@ -238,24 +238,25 @@ export function setUpUI() {
   const iceServerInputUrlElem = document.getElementById('ice-server-url-input');
   iceServerInputUrlElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerUrl = event.target.value
-      .trim();
+    channel.additionalIceServerUrl = event.target.value.trim();
     // @ts-ignore
     iceServerInputUrlElem.value = channel.additionalIceServerUrl;
   });
-  const iceServerInputUserElem = document.getElementById('ice-server-user-input');
+  const iceServerInputUserElem = document.getElementById(
+    'ice-server-username-input'
+  );
   iceServerInputUserElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerUser = event.target.value
-      .trim();
+    channel.additionalIceServerUser = event.target.value.trim();
     // @ts-ignore
     iceServerInputUserElem.value = channel.additionalIceServerUser;
   });
-  const iceServerInputPassElem = document.getElementById('ice-server-pass-input');
+  const iceServerInputPassElem = document.getElementById(
+    'ice-server-credential-input'
+  );
   iceServerInputPassElem.addEventListener('input', (event) => {
     // @ts-ignore
-    channel.additionalIceServerPass = event.target.value
-      .trim();
+    channel.additionalIceServerPass = event.target.value.trim();
     // @ts-ignore
     iceServerInputPassElem.value = channel.additionalIceServerPass;
   });

--- a/src/resources/js/ui_online.js
+++ b/src/resources/js/ui_online.js
@@ -223,6 +223,43 @@ export function setUpUI() {
     }
   });
 
+  const webrtcSettingsBtn = document.getElementById('webrtc-settings-btn');
+  webrtcSettingsBtn.addEventListener('click', () => {
+    const webrtcSettingsContainer = document.getElementById(
+      'webrtc-settings-container'
+    );
+    if (webrtcSettingsContainer.classList.contains('hidden')) {
+      webrtcSettingsContainer.classList.remove('hidden');
+    } else {
+      webrtcSettingsContainer.classList.add('hidden');
+    }
+  });
+
+  const iceServerInputUrlElem = document.getElementById('ice-server-url-input');
+  iceServerInputUrlElem.addEventListener('input', (event) => {
+    // @ts-ignore
+    channel.additionalIceServerUrl = event.target.value
+      .trim();
+    // @ts-ignore
+    iceServerInputUrlElem.value = channel.additionalIceServerUrl;
+  });
+  const iceServerInputUserElem = document.getElementById('ice-server-user-input');
+  iceServerInputUserElem.addEventListener('input', (event) => {
+    // @ts-ignore
+    channel.additionalIceServerUser = event.target.value
+      .trim();
+    // @ts-ignore
+    iceServerInputUserElem.value = channel.additionalIceServerUser;
+  });
+  const iceServerInputPassElem = document.getElementById('ice-server-pass-input');
+  iceServerInputPassElem.addEventListener('input', (event) => {
+    // @ts-ignore
+    channel.additionalIceServerPass = event.target.value
+      .trim();
+    // @ts-ignore
+    iceServerInputPassElem.value = channel.additionalIceServerPass;
+  });
+
   // For auto-fast-speed-checkbox
   const autoFastSpeedCheckboxElem = document.getElementById(
     'auto-fast-speed-checkbox'

--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -12,6 +12,7 @@
   --btn-height: calc(2 * var(--font-size));
   --color-black: #232629;
 }
+
 :root {
   --background-color: #ffffff;
   --background-color-with-alpha: rgba(255, 255, 255, 0.8);
@@ -33,6 +34,7 @@
   --update-fade-in-box-background-color: rgba(226, 230, 36, 0.85);
   --amount-to-invert-image: 0;
 }
+
 @media (prefers-color-scheme: dark) {
   :root {
     --background-color: #202124;
@@ -53,6 +55,7 @@
     --amount-to-invert-image: 0.95;
   }
 }
+
 /* Copy of the variables in :root above */
 :root[data-color-scheme='light'] {
   --background-color: #ffffff;
@@ -75,6 +78,7 @@
   --update-fade-in-box-background-color: rgba(226, 230, 36, 0.85);
   --amount-to-invert-image: 0;
 }
+
 /* Copy of the variables in @media (prefers-color-scheme: dark) :root above */
 :root[data-color-scheme='dark'] {
   --background-color: #202124;
@@ -94,6 +98,7 @@
   --update-fade-in-box-background-color: rgba(195, 197, 48, 0.85);
   --amount-to-invert-image: 0.95;
 }
+
 /* size of iPad screen is 768px x 1024px in portrait mode */
 @media only screen and (min-width: 768px) and (min-height: 768px) {
   :root {
@@ -104,46 +109,56 @@
     );
   }
 }
+
 @media only screen and (min-aspect-ratio: 432/304) {
   :root {
     --canvas-height: calc(92vh - 2.5 * var(--btn-height) - 10px);
     --canvas-width: calc(var(--canvas-height) * var(--aspect-ratio));
   }
 }
+
 @media only screen and (max-aspect-ratio: 432/304) {
   :root {
     --canvas-width: 92vw;
     --canvas-height: calc(var(--canvas-width) * var(--inverse-aspect-ratio));
   }
 }
+
 html {
   box-sizing: border-box;
 }
+
 *,
 *:before,
 *:after {
   box-sizing: inherit;
 }
+
 * {
   font-family: Arial, Helvetica, sans-serif;
 }
+
 body {
   background-color: var(--background-color);
   color: var(--color);
   margin: 0;
 }
+
 a,
 a:link,
 a:visited {
   color: var(--link-color);
   text-decoration: none;
 }
+
 a:hover {
   color: var(--link-hover-color);
 }
+
 a:active {
   color: var(--link-hover-color);
 }
+
 #flex-container,
 #before-connection,
 #update-history-container {
@@ -160,6 +175,7 @@ a:active {
   padding-top: 8px;
   padding-bottom: 8px;
 }
+
 #before-connection,
 #update-history-container {
   justify-content: center;
@@ -171,6 +187,7 @@ a:active {
   overflow: visible;
   text-align: left;
 }
+
 #about-box-head {
   display: flex;
   flex-wrap: wrap;
@@ -183,14 +200,17 @@ a:active {
   visibility: visible;
   overflow: visible;
 }
+
 #flex-container.hidden,
 #before-connection.hidden {
   display: none;
 }
+
 #game-canvas-container {
   margin-left: auto;
   margin-right: auto;
 }
+
 #game-canvas-container,
 canvas {
   position: relative;
@@ -199,18 +219,23 @@ canvas {
   height: var(--canvas-height);
   image-rendering: pixelated;
 }
+
 canvas.graphic-soft {
   image-rendering: auto;
 }
+
 #nicknames-container {
   position: absolute;
 }
+
 #player1-chat-box {
   right: 70%;
 }
+
 #player2-chat-box {
   left: 70%;
 }
+
 .chat-box {
   z-index: 20;
   position: absolute;
@@ -225,26 +250,32 @@ canvas.graphic-soft {
   animation-name: fade-inout;
   animation-duration: 5s;
 }
+
 .chat-box.in-speech-bubble {
   color: var(--color-black);
   background-color: rgba(255, 255, 255, 0.95);
 }
+
 @keyframes fade-inout {
   0% {
     visibility: visible;
     opacity: 0;
   }
+
   25% {
     opacity: 1;
   }
+
   75% {
     opacity: 1;
   }
+
   100% {
     visibility: hidden;
     opacity: 0;
   }
 }
+
 #chat-input-here {
   position: relative;
   display: block;
@@ -253,6 +284,7 @@ canvas.graphic-soft {
   margin-right: auto;
   width: var(--canvas-width);
 }
+
 #chat-input-and-send-btn-container,
 #chat-open-btn-and-chat-disabling-btn-container,
 #room-id-with-join-btn,
@@ -264,13 +296,16 @@ canvas.graphic-soft {
   grid-template-columns: auto var(--btn-width);
   align-items: center;
 }
+
 #create-btn-with-created-room-id {
   grid-template-columns: var(--btn-width) auto var(--btn-width);
 }
+
 .nickname-input-container,
 #room-id-with-join-btn {
   margin-top: calc(var(--btn-height) / 2);
 }
+
 #checkbox-container,
 #chat-open-btn,
 #chat-input,
@@ -279,35 +314,42 @@ canvas.graphic-soft {
   width: 100%;
   height: 100%;
 }
+
 #chat-input {
   grid-column-start: 1;
 }
+
 #chat-disabling-btn,
 #send-btn {
   grid-column-start: 2;
   border-radius: 0;
   border-width: 1px;
 }
+
 #chat-open-btn {
   text-align: center;
   border-radius: 0;
   border-width: 1px;
 }
+
 #chat-input-and-send-btn-container,
 #chat-open-btn-and-chat-disabling-btn-container {
   position: absolute;
   display: grid;
 }
+
 #menu-bar.hidden,
 #chat-input-and-send-btn-container.hidden,
 #chat-open-btn-and-chat-disabling-btn-container.hidden {
   display: none;
 }
+
 #chat-input-here,
 #chat-input-and-send-btn-container,
 #chat-open-btn-and-chat-disabling-btn-container {
   width: var(--canvas-width);
 }
+
 #network-test-btn,
 #create-btn,
 #exit-room-btn,
@@ -315,12 +357,13 @@ canvas.graphic-soft {
 #nickname-input,
 #webrtc-settings-btn,
 #ice-server-url-input,
-#ice-server-user-input,
-#ice-server-pass-input,
+#ice-server-username-input,
+#ice-server-credential-input,
 #join-btn {
   width: 100%;
   height: var(--btn-height);
 }
+
 #copy-btn {
   width: calc(var(--btn-width) / 1.5);
   height: var(--btn-height);
@@ -330,10 +373,12 @@ canvas.graphic-soft {
   margin-left: 20px;
   margin-right: 10px;
 }
+
 #join-room-id-input,
 #create-btn {
   grid-column-start: 1;
 }
+
 #network-test-btn,
 #create-btn,
 #exit-room-btn,
@@ -344,35 +389,42 @@ canvas.graphic-soft {
 #copy-btn {
   font-size: calc(0.8 * var(--font-size));
 }
+
 #created-room-id-container,
 #join-room-id-input,
 #nickname-input,
 #ice-server-url-input,
-#ice-server-user-input,
-#ice-server-pass-input,
+#ice-server-username-input,
+#ice-server-credential-input,
 #chat-input {
   font-size: var(--font-size);
 }
+
 #join-btn,
 #created-room-id-container {
   grid-column-start: 2;
 }
+
 #created-room-id-container {
   display: flex;
   align-items: center;
 }
+
 #quick-match-log-container {
   width: 100%;
   font-size: var(--font-size);
 }
+
 div.log {
   width: 100%;
   font-size: var(--font-size);
 }
+
 #container-for-margin {
   min-height: 50vh;
   width: 100%;
 }
+
 p.languages,
 p.small,
 p.offline-version,
@@ -384,26 +436,33 @@ p.update-history-on {
   font-size: 0.8em;
   line-height: 150%;
 }
+
 p.release-date {
   margin-block-end: 0;
 }
+
 p.update-history-on {
   margin-block-start: 0;
   margin-block-end: 0;
 }
+
 span.no-wrap {
   white-space: nowrap;
 }
+
 span.bold {
   font-weight: bold;
 }
+
 span.thick {
   font-weight: 900;
 }
+
 span.margin-left-right {
   margin-left: 10px;
   margin-right: 10px;
 }
+
 .fade-in-box {
   position: absolute;
   display: flex;
@@ -428,31 +487,39 @@ span.margin-left-right {
   animation-name: fade-in;
   animation-duration: 1s;
 }
+
 @keyframes fade-in {
   0% {
     opacity: 0;
   }
+
   100% {
     opacity: 1;
   }
 }
+
 .fade-in-box.hidden {
   display: none;
 }
+
 .fade-in-box.black {
   background-color: black;
   color: white;
   animation-duration: 0s;
 }
+
 .fade-in-box.peer-loading {
   z-index: 5;
 }
+
 .fade-in-box.loading {
   z-index: 6;
 }
+
 .fade-in-box.ping {
   z-index: 7;
 }
+
 #progress-bar-border {
   position: relative;
   border: solid;
@@ -460,6 +527,7 @@ span.margin-left-right {
   height: var(--btn-height);
   width: calc(var(--canvas-width) / 2);
 }
+
 #progress-bar {
   position: absolute;
   top: 0;
@@ -468,6 +536,7 @@ span.margin-left-right {
   height: 100%;
   background-color: white;
 }
+
 button {
   display: inline-block;
   border: 2px solid var(--btn-border-color);
@@ -480,14 +549,17 @@ button {
   text-decoration: none;
   border-radius: 5px;
 }
+
 input {
   border-color: var(--color-black);
 }
+
 button:disabled,
 input:disabled {
   border-color: var(--button-disabled-color);
   color: var(--button-disabled-color);
 }
+
 button.btn-in-box {
   display: block;
   height: calc(2 * var(--font-size));
@@ -503,54 +575,67 @@ button.btn-in-box {
   text-decoration: none;
   border-radius: 10px;
 }
+
 #ask-one-more-game button.btn-in-box {
   width: calc(7 * var(--font-size));
 }
+
 button.large {
   height: calc(3 * var(--font-size));
   width: calc(7 * var(--font-size));
 }
+
 button.very-large {
   height: calc(4 * var(--font-size));
   width: calc(8 * var(--font-size));
 }
+
 img.screenshot,
 img.controls {
   height: auto;
   width: 100%;
 }
+
 img.screenshot {
   max-width: 864px;
 }
+
 img.controls {
   max-width: 950px;
   filter: invert(var(--amount-to-invert-image));
 }
+
 div.hidden,
 span.hidden,
 button.hidden,
 audio.hidden {
   display: none;
 }
+
 div.margin-top,
 p.margin-top {
   margin-top: calc(2.5 * var(--font-size));
 }
+
 div.margin-top-a-little {
   margin-top: var(--font-size);
 }
+
 div.margin-top-very-little {
   margin-top: calc(0.5 * var(--font-size));
 }
+
 div.limit-width {
   max-width: 864px;
   margin-left: auto;
   margin-right: auto;
 }
+
 ul {
   margin-top: var(--font-size);
   margin-bottom: var(--font-size);
 }
+
 div.grid-1-1 {
   display: grid;
   width: 100%;
@@ -558,10 +643,12 @@ div.grid-1-1 {
   grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
+
 div.grid-1-1.center {
   width: auto;
   height: auto;
 }
+
 div.fixed {
   position: fixed;
   top: 0;
@@ -569,20 +656,25 @@ div.fixed {
   width: 100vw;
   height: 100vh;
 }
+
 #quick-match-btn {
   grid-column-start: 1;
   font-size: var(--font-size);
 }
+
 #with-your-friend-btn {
   grid-column-start: 2;
   font-size: var(--font-size);
 }
+
 div.scroll {
   overflow: scroll;
 }
+
 button:disabled {
   background-color: var(--button-disabled-background-color);
 }
+
 #menu-bar {
   display: grid;
   width: var(--canvas-width);
@@ -590,6 +682,7 @@ button:disabled {
   grid-template-columns: 2fr 1fr;
   margin-bottom: 10px;
 }
+
 button.btn {
   display: inline-block;
   grid-row-start: 1;
@@ -607,66 +700,84 @@ button.btn {
   margin-left: 5px;
   margin-right: 5px;
 }
+
 button.btn:disabled {
   background-color: var(--button-disabled-background-color);
 }
+
 button.btn.hidden {
   display: none;
 }
+
 #options-dropdown-btn {
   margin-left: 0;
 }
+
 #exit-btn {
   margin-right: 0;
 }
+
 .relative-container {
   position: relative;
 }
+
 .dropdown,
 .submenu {
   position: absolute;
   display: none;
   z-index: 16;
 }
+
 .dropdown.show {
   display: block;
 }
+
 .submenu.show {
   display: inline-block;
 }
+
 .dropdown .btn {
   margin-right: 0;
   background-color: var(--btn-in-dropdown-background-color);
 }
+
 .submenu > .btn {
   width: calc(1.4 * var(--btn-width));
   margin-left: 0;
 }
+
 .dropdown .btn:hover,
 .submenu-btn.open {
   background-color: var(--btn-in-dropdown-hover-background-color);
 }
+
 span.check {
   display: none;
 }
+
 .selected > span.check {
   display: inline;
 }
+
 .pre-wrap {
   white-space: pre-wrap;
 }
+
 #update-history-container h1 {
   font-size: calc(1.5 * var(--font-size));
 }
+
 div.indent-minus {
   text-indent: calc(-5.4 * var(--font-size));
   margin-left: calc(5.4 * var(--font-size));
 }
+
 div.nicknames-container {
   position: absolute;
   top: 0;
   left: 50%;
-  margin-left: -35%; /* half of width */
+  margin-left: -35%;
+  /* half of width */
   display: grid;
   grid-template-columns: 1fr 1fr;
   column-gap: calc(1.5 * var(--font-size));
@@ -674,31 +785,39 @@ div.nicknames-container {
   height: calc(4 * var(--font-size));
   z-index: 9;
 }
+
 .nickname-and-partial-ip {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
   justify-content: flex-start;
 }
+
 .nickname-and-partial-ip.left {
   align-items: flex-end;
 }
+
 .nickname-and-partial-ip.right {
   align-items: flex-start;
 }
+
 .nickname,
 .partial-ip {
   color: white;
 }
+
 .nickname {
   font-size: calc(1.1 * var(--font-size));
 }
+
 .partial-ip {
   font-size: calc(0.8 * var(--font-size));
 }
+
 .text-align-start {
   text-align: start;
 }
+
 .match-group-btns-container {
   display: flex;
   flex-direction: row;
@@ -706,56 +825,69 @@ div.nicknames-container {
   justify-content: center;
   gap: calc(1 * var(--font-size));
 }
+
 /* CSS for replay is below */
 #dropbox {
   border-style: solid;
   border-color: var(--color);
   border-width: 2px;
 }
+
 .btn-container {
   display: flex;
   align-items: center;
   justify-content: flex-start;
 }
+
 .btn-container.left {
   grid-column-start: 1;
   justify-content: flex-start;
 }
+
 .btn-container.right {
   grid-column-start: 2;
   justify-content: flex-end;
 }
+
 #scrubber-range-input {
   width: var(--canvas-width);
   height: var(--btn-height);
 }
+
 span.margin-left-right {
   margin-left: calc(var(--font-size) / 1.5);
   margin-right: calc(var(--font-size) / 1.5);
 }
+
 button.btn-for-replay {
   height: var(--btn-height);
   width: calc(var(--btn-width) / 2);
   font-size: calc(var(--font-size) / 1.2);
 }
+
 button.btn-for-replay.selected {
   background-color: rgb(50, 163, 255);
   background-image: none;
   color: white;
   font-weight: bold;
 }
+
 #play-pause-btn {
   font-size: var(--font-size);
 }
+
 div.inline {
   display: inline;
 }
+
 div.margin-top-little {
   margin-top: calc(var(--font-size) / 1.5);
 }
+
 input[type='file'] {
   display: none;
 }
+
 label.custom-file-upload {
   display: flex;
   justify-content: center;
@@ -771,15 +903,18 @@ label.custom-file-upload {
   height: var(--btn-height);
   cursor: pointer;
 }
+
 .disable-dbl-tap-zoom {
   touch-action: manipulation;
 }
+
 .flex-for-keyboard {
   display: flex;
   flex-direction: row;
   justify-content: space-around;
   margin-top: 10px;
 }
+
 .grid-for-keyboard {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
@@ -788,31 +923,37 @@ label.custom-file-upload {
   width: calc(5 * var(--btn-height));
   height: calc(2.3 * var(--btn-height));
 }
+
 #z-key,
 #enter-key {
   grid-row-start: 1;
   grid-column-start: 1;
 }
+
 #r-key,
 #up-key {
   grid-row-start: 1;
   grid-column-start: 3;
 }
+
 #d-key,
 #left-key {
   grid-row-start: 2;
   grid-column-start: 2;
 }
+
 #v-key,
 #down-key {
   grid-row-start: 2;
   grid-column-start: 3;
 }
+
 #g-key,
 #right-key {
   grid-row-start: 2;
   grid-column-start: 4;
 }
+
 .keyboard-key {
   display: flex;
   justify-content: center;
@@ -820,38 +961,47 @@ label.custom-file-upload {
   border: 2px solid rgb(50, 50, 50);
   font-size: var(--font-size);
 }
+
 .keyboard-key.pressed {
   background-color: rgb(255, 0, 0);
   color: white;
 }
+
 #show-hide-keyboard-btn {
   font-size: calc(var(--font-size) / 1.3);
   width: var(--btn-width);
 }
+
 div.show-checkboxes-container {
   font-size: calc(var(--font-size) / 1.2);
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
 }
+
 label[for='fps-input'] {
   margin-left: 10px;
 }
+
 #fps-input {
   height: var(--btn-height);
   width: calc(var(--btn-width) / 2);
   font-size: calc(var(--font-size) / 1.2);
 }
+
 .open-chat-list {
   margin-block-start: 1em;
   margin-block-end: 0;
 }
+
 .open-chat-list li {
   margin-top: 10px;
 }
+
 .no-margin-top {
   margin-top: 0;
 }
+
 .if-embedded-in-other-website {
   display: flex;
   flex-direction: column;
@@ -864,9 +1014,11 @@ label[for='fps-input'] {
   border: 3px solid;
   border-radius: 10px;
 }
+
 .if-embedded-in-other-website .limit-width {
   max-width: calc(23 * var(--font-size));
 }
+
 .if-embedded-in-other-website button {
   margin-top: var(--font-size);
   background-color: var(--background-color);
@@ -876,9 +1028,11 @@ label[for='fps-input'] {
   height: calc(1.6 * var(--font-size));
   width: calc(4 * var(--font-size));
 }
+
 .original-address {
   margin-top: var(--font-size);
 }
+
 table.blocked-ip-addresses-table {
   /* box-sizing below is necessary for Chrome and Safari, not for Firefox.
      Is it a bug in Chrome and Safari? */
@@ -887,37 +1041,45 @@ table.blocked-ip-addresses-table {
   border: 2px solid rgb(200, 200, 200);
   width: 100%;
 }
+
 table.blocked-ip-addresses-table th,
 table.blocked-ip-addresses-table td {
   border: 1px solid rgb(190, 190, 190);
   padding: 5px;
   text-align: center;
 }
+
 table.blocked-ip-addresses-table tbody td {
   cursor: default;
 }
+
 table.blocked-ip-addresses-table tfoot td {
   padding: 0;
 }
+
 table.blocked-ip-addresses-table tr.selected {
   background-color: var(--link-hover-color);
 }
+
 table.blocked-ip-addresses-table input {
   width: 100%;
   height: 100%;
   border: none;
   font-size: var(--font-size);
 }
+
 table.blocked-ip-addresses-table .delete-btn {
   height: 100%;
   width: 100%;
   font-size: var(--font-size);
 }
+
 details {
   border: 1px solid #aaa;
   border-radius: 4px;
   padding: 0;
 }
+
 summary {
   /* box-sizing below is necessary for Chrome and Safari, not for Firefox.
      Is it a bug in Chrome and Safari? */
@@ -925,6 +1087,7 @@ summary {
   font-weight: bold;
   padding: 0.5em;
 }
+
 div.color-scheme-toggle-switch-container {
   display: flex;
   justify-content: center;
@@ -945,6 +1108,7 @@ div.color-scheme-toggle-switch-container {
       var(--toggle-ball-left)
   );
 }
+
 /*
  * Toggle switch using CSS
  * Reference: https://dev.to/karankmr/how-to-create-a-custom-toggle-switch-using-css-4pmi
@@ -952,6 +1116,7 @@ div.color-scheme-toggle-switch-container {
 input.toggle-switch {
   display: none;
 }
+
 input.toggle-switch + label {
   display: inline-block;
   position: relative;
@@ -963,6 +1128,7 @@ input.toggle-switch + label {
   cursor: pointer;
   transition: background-color 1s;
 }
+
 input.toggle-switch + label::after {
   content: '';
   position: absolute;
@@ -974,9 +1140,11 @@ input.toggle-switch + label::after {
   background-color: var(--btn-color);
   transition: left 0.5s, background-color 1s;
 }
+
 input.toggle-switch:checked + label::after {
   left: var(--toggle-ball-left-toggled);
 }
+
 /*
  * The following supplement is for displaying the Sun and Moon unicode characters
  * inside toggle switch label.
@@ -994,6 +1162,7 @@ input.toggle-switch + label::before {
   font-size: var(--toggle-ball-diameter);
   content: '\2600';
 }
+
 input.toggle-switch:checked + label::before {
   left: var(--toggle-ball-left);
   content: '\263E';

--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -313,6 +313,10 @@ canvas.graphic-soft {
 #exit-room-btn,
 #join-room-id-input,
 #nickname-input,
+#webrtc-settings-btn,
+#ice-server-url-input,
+#ice-server-user-input,
+#ice-server-pass-input,
 #join-btn {
   width: 100%;
   height: var(--btn-height);
@@ -343,6 +347,9 @@ canvas.graphic-soft {
 #created-room-id-container,
 #join-room-id-input,
 #nickname-input,
+#ice-server-url-input,
+#ice-server-user-input,
+#ice-server-pass-input,
 #chat-input {
   font-size: var(--font-size);
 }

--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -12,7 +12,6 @@
   --btn-height: calc(2 * var(--font-size));
   --color-black: #232629;
 }
-
 :root {
   --background-color: #ffffff;
   --background-color-with-alpha: rgba(255, 255, 255, 0.8);
@@ -34,7 +33,6 @@
   --update-fade-in-box-background-color: rgba(226, 230, 36, 0.85);
   --amount-to-invert-image: 0;
 }
-
 @media (prefers-color-scheme: dark) {
   :root {
     --background-color: #202124;
@@ -55,7 +53,6 @@
     --amount-to-invert-image: 0.95;
   }
 }
-
 /* Copy of the variables in :root above */
 :root[data-color-scheme='light'] {
   --background-color: #ffffff;
@@ -78,7 +75,6 @@
   --update-fade-in-box-background-color: rgba(226, 230, 36, 0.85);
   --amount-to-invert-image: 0;
 }
-
 /* Copy of the variables in @media (prefers-color-scheme: dark) :root above */
 :root[data-color-scheme='dark'] {
   --background-color: #202124;
@@ -98,7 +94,6 @@
   --update-fade-in-box-background-color: rgba(195, 197, 48, 0.85);
   --amount-to-invert-image: 0.95;
 }
-
 /* size of iPad screen is 768px x 1024px in portrait mode */
 @media only screen and (min-width: 768px) and (min-height: 768px) {
   :root {
@@ -109,56 +104,46 @@
     );
   }
 }
-
 @media only screen and (min-aspect-ratio: 432/304) {
   :root {
     --canvas-height: calc(92vh - 2.5 * var(--btn-height) - 10px);
     --canvas-width: calc(var(--canvas-height) * var(--aspect-ratio));
   }
 }
-
 @media only screen and (max-aspect-ratio: 432/304) {
   :root {
     --canvas-width: 92vw;
     --canvas-height: calc(var(--canvas-width) * var(--inverse-aspect-ratio));
   }
 }
-
 html {
   box-sizing: border-box;
 }
-
 *,
 *:before,
 *:after {
   box-sizing: inherit;
 }
-
 * {
   font-family: Arial, Helvetica, sans-serif;
 }
-
 body {
   background-color: var(--background-color);
   color: var(--color);
   margin: 0;
 }
-
 a,
 a:link,
 a:visited {
   color: var(--link-color);
   text-decoration: none;
 }
-
 a:hover {
   color: var(--link-hover-color);
 }
-
 a:active {
   color: var(--link-hover-color);
 }
-
 #flex-container,
 #before-connection,
 #update-history-container {
@@ -175,7 +160,6 @@ a:active {
   padding-top: 8px;
   padding-bottom: 8px;
 }
-
 #before-connection,
 #update-history-container {
   justify-content: center;
@@ -187,7 +171,6 @@ a:active {
   overflow: visible;
   text-align: left;
 }
-
 #about-box-head {
   display: flex;
   flex-wrap: wrap;
@@ -200,17 +183,14 @@ a:active {
   visibility: visible;
   overflow: visible;
 }
-
 #flex-container.hidden,
 #before-connection.hidden {
   display: none;
 }
-
 #game-canvas-container {
   margin-left: auto;
   margin-right: auto;
 }
-
 #game-canvas-container,
 canvas {
   position: relative;
@@ -219,23 +199,18 @@ canvas {
   height: var(--canvas-height);
   image-rendering: pixelated;
 }
-
 canvas.graphic-soft {
   image-rendering: auto;
 }
-
 #nicknames-container {
   position: absolute;
 }
-
 #player1-chat-box {
   right: 70%;
 }
-
 #player2-chat-box {
   left: 70%;
 }
-
 .chat-box {
   z-index: 20;
   position: absolute;
@@ -250,32 +225,26 @@ canvas.graphic-soft {
   animation-name: fade-inout;
   animation-duration: 5s;
 }
-
 .chat-box.in-speech-bubble {
   color: var(--color-black);
   background-color: rgba(255, 255, 255, 0.95);
 }
-
 @keyframes fade-inout {
   0% {
     visibility: visible;
     opacity: 0;
   }
-
   25% {
     opacity: 1;
   }
-
   75% {
     opacity: 1;
   }
-
   100% {
     visibility: hidden;
     opacity: 0;
   }
 }
-
 #chat-input-here {
   position: relative;
   display: block;
@@ -284,7 +253,6 @@ canvas.graphic-soft {
   margin-right: auto;
   width: var(--canvas-width);
 }
-
 #chat-input-and-send-btn-container,
 #chat-open-btn-and-chat-disabling-btn-container,
 #room-id-with-join-btn,
@@ -296,16 +264,13 @@ canvas.graphic-soft {
   grid-template-columns: auto var(--btn-width);
   align-items: center;
 }
-
 #create-btn-with-created-room-id {
   grid-template-columns: var(--btn-width) auto var(--btn-width);
 }
-
 .nickname-input-container,
 #room-id-with-join-btn {
   margin-top: calc(var(--btn-height) / 2);
 }
-
 #checkbox-container,
 #chat-open-btn,
 #chat-input,
@@ -314,42 +279,35 @@ canvas.graphic-soft {
   width: 100%;
   height: 100%;
 }
-
 #chat-input {
   grid-column-start: 1;
 }
-
 #chat-disabling-btn,
 #send-btn {
   grid-column-start: 2;
   border-radius: 0;
   border-width: 1px;
 }
-
 #chat-open-btn {
   text-align: center;
   border-radius: 0;
   border-width: 1px;
 }
-
 #chat-input-and-send-btn-container,
 #chat-open-btn-and-chat-disabling-btn-container {
   position: absolute;
   display: grid;
 }
-
 #menu-bar.hidden,
 #chat-input-and-send-btn-container.hidden,
 #chat-open-btn-and-chat-disabling-btn-container.hidden {
   display: none;
 }
-
 #chat-input-here,
 #chat-input-and-send-btn-container,
 #chat-open-btn-and-chat-disabling-btn-container {
   width: var(--canvas-width);
 }
-
 #network-test-btn,
 #create-btn,
 #exit-room-btn,
@@ -357,13 +315,12 @@ canvas.graphic-soft {
 #nickname-input,
 #webrtc-settings-btn,
 #ice-server-url-input,
-#ice-server-username-input,
-#ice-server-credential-input,
+#ice-server-user-input,
+#ice-server-pass-input,
 #join-btn {
   width: 100%;
   height: var(--btn-height);
 }
-
 #copy-btn {
   width: calc(var(--btn-width) / 1.5);
   height: var(--btn-height);
@@ -373,12 +330,10 @@ canvas.graphic-soft {
   margin-left: 20px;
   margin-right: 10px;
 }
-
 #join-room-id-input,
 #create-btn {
   grid-column-start: 1;
 }
-
 #network-test-btn,
 #create-btn,
 #exit-room-btn,
@@ -389,42 +344,35 @@ canvas.graphic-soft {
 #copy-btn {
   font-size: calc(0.8 * var(--font-size));
 }
-
 #created-room-id-container,
 #join-room-id-input,
 #nickname-input,
 #ice-server-url-input,
-#ice-server-username-input,
-#ice-server-credential-input,
+#ice-server-user-input,
+#ice-server-pass-input,
 #chat-input {
   font-size: var(--font-size);
 }
-
 #join-btn,
 #created-room-id-container {
   grid-column-start: 2;
 }
-
 #created-room-id-container {
   display: flex;
   align-items: center;
 }
-
 #quick-match-log-container {
   width: 100%;
   font-size: var(--font-size);
 }
-
 div.log {
   width: 100%;
   font-size: var(--font-size);
 }
-
 #container-for-margin {
   min-height: 50vh;
   width: 100%;
 }
-
 p.languages,
 p.small,
 p.offline-version,
@@ -436,33 +384,26 @@ p.update-history-on {
   font-size: 0.8em;
   line-height: 150%;
 }
-
 p.release-date {
   margin-block-end: 0;
 }
-
 p.update-history-on {
   margin-block-start: 0;
   margin-block-end: 0;
 }
-
 span.no-wrap {
   white-space: nowrap;
 }
-
 span.bold {
   font-weight: bold;
 }
-
 span.thick {
   font-weight: 900;
 }
-
 span.margin-left-right {
   margin-left: 10px;
   margin-right: 10px;
 }
-
 .fade-in-box {
   position: absolute;
   display: flex;
@@ -487,39 +428,31 @@ span.margin-left-right {
   animation-name: fade-in;
   animation-duration: 1s;
 }
-
 @keyframes fade-in {
   0% {
     opacity: 0;
   }
-
   100% {
     opacity: 1;
   }
 }
-
 .fade-in-box.hidden {
   display: none;
 }
-
 .fade-in-box.black {
   background-color: black;
   color: white;
   animation-duration: 0s;
 }
-
 .fade-in-box.peer-loading {
   z-index: 5;
 }
-
 .fade-in-box.loading {
   z-index: 6;
 }
-
 .fade-in-box.ping {
   z-index: 7;
 }
-
 #progress-bar-border {
   position: relative;
   border: solid;
@@ -527,7 +460,6 @@ span.margin-left-right {
   height: var(--btn-height);
   width: calc(var(--canvas-width) / 2);
 }
-
 #progress-bar {
   position: absolute;
   top: 0;
@@ -536,7 +468,6 @@ span.margin-left-right {
   height: 100%;
   background-color: white;
 }
-
 button {
   display: inline-block;
   border: 2px solid var(--btn-border-color);
@@ -549,17 +480,14 @@ button {
   text-decoration: none;
   border-radius: 5px;
 }
-
 input {
   border-color: var(--color-black);
 }
-
 button:disabled,
 input:disabled {
   border-color: var(--button-disabled-color);
   color: var(--button-disabled-color);
 }
-
 button.btn-in-box {
   display: block;
   height: calc(2 * var(--font-size));
@@ -575,67 +503,54 @@ button.btn-in-box {
   text-decoration: none;
   border-radius: 10px;
 }
-
 #ask-one-more-game button.btn-in-box {
   width: calc(7 * var(--font-size));
 }
-
 button.large {
   height: calc(3 * var(--font-size));
   width: calc(7 * var(--font-size));
 }
-
 button.very-large {
   height: calc(4 * var(--font-size));
   width: calc(8 * var(--font-size));
 }
-
 img.screenshot,
 img.controls {
   height: auto;
   width: 100%;
 }
-
 img.screenshot {
   max-width: 864px;
 }
-
 img.controls {
   max-width: 950px;
   filter: invert(var(--amount-to-invert-image));
 }
-
 div.hidden,
 span.hidden,
 button.hidden,
 audio.hidden {
   display: none;
 }
-
 div.margin-top,
 p.margin-top {
   margin-top: calc(2.5 * var(--font-size));
 }
-
 div.margin-top-a-little {
   margin-top: var(--font-size);
 }
-
 div.margin-top-very-little {
   margin-top: calc(0.5 * var(--font-size));
 }
-
 div.limit-width {
   max-width: 864px;
   margin-left: auto;
   margin-right: auto;
 }
-
 ul {
   margin-top: var(--font-size);
   margin-bottom: var(--font-size);
 }
-
 div.grid-1-1 {
   display: grid;
   width: 100%;
@@ -643,12 +558,10 @@ div.grid-1-1 {
   grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
-
 div.grid-1-1.center {
   width: auto;
   height: auto;
 }
-
 div.fixed {
   position: fixed;
   top: 0;
@@ -656,25 +569,20 @@ div.fixed {
   width: 100vw;
   height: 100vh;
 }
-
 #quick-match-btn {
   grid-column-start: 1;
   font-size: var(--font-size);
 }
-
 #with-your-friend-btn {
   grid-column-start: 2;
   font-size: var(--font-size);
 }
-
 div.scroll {
   overflow: scroll;
 }
-
 button:disabled {
   background-color: var(--button-disabled-background-color);
 }
-
 #menu-bar {
   display: grid;
   width: var(--canvas-width);
@@ -682,7 +590,6 @@ button:disabled {
   grid-template-columns: 2fr 1fr;
   margin-bottom: 10px;
 }
-
 button.btn {
   display: inline-block;
   grid-row-start: 1;
@@ -700,84 +607,66 @@ button.btn {
   margin-left: 5px;
   margin-right: 5px;
 }
-
 button.btn:disabled {
   background-color: var(--button-disabled-background-color);
 }
-
 button.btn.hidden {
   display: none;
 }
-
 #options-dropdown-btn {
   margin-left: 0;
 }
-
 #exit-btn {
   margin-right: 0;
 }
-
 .relative-container {
   position: relative;
 }
-
 .dropdown,
 .submenu {
   position: absolute;
   display: none;
   z-index: 16;
 }
-
 .dropdown.show {
   display: block;
 }
-
 .submenu.show {
   display: inline-block;
 }
-
 .dropdown .btn {
   margin-right: 0;
   background-color: var(--btn-in-dropdown-background-color);
 }
-
 .submenu > .btn {
   width: calc(1.4 * var(--btn-width));
   margin-left: 0;
 }
-
 .dropdown .btn:hover,
 .submenu-btn.open {
   background-color: var(--btn-in-dropdown-hover-background-color);
 }
-
 span.check {
   display: none;
 }
-
 .selected > span.check {
   display: inline;
 }
-
 .pre-wrap {
   white-space: pre-wrap;
 }
-
 #update-history-container h1 {
   font-size: calc(1.5 * var(--font-size));
 }
-
 div.indent-minus {
   text-indent: calc(-5.4 * var(--font-size));
   margin-left: calc(5.4 * var(--font-size));
 }
-
 div.nicknames-container {
   position: absolute;
   top: 0;
   left: 50%;
-  margin-left: -35%;
-  /* half of width */
+  margin-left: -35%; /* half of width */
   display: grid;
   grid-template-columns: 1fr 1fr;
   column-gap: calc(1.5 * var(--font-size));
@@ -785,39 +674,31 @@ div.nicknames-container {
   height: calc(4 * var(--font-size));
   z-index: 9;
 }
-
 .nickname-and-partial-ip {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
   justify-content: flex-start;
 }
-
 .nickname-and-partial-ip.left {
   align-items: flex-end;
 }
-
 .nickname-and-partial-ip.right {
   align-items: flex-start;
 }
-
 .nickname,
 .partial-ip {
   color: white;
 }
-
 .nickname {
   font-size: calc(1.1 * var(--font-size));
 }
-
 .partial-ip {
   font-size: calc(0.8 * var(--font-size));
 }
-
 .text-align-start {
   text-align: start;
 }
-
 .match-group-btns-container {
   display: flex;
   flex-direction: row;
@@ -825,69 +706,56 @@ div.nicknames-container {
   justify-content: center;
   gap: calc(1 * var(--font-size));
 }
-
 /* CSS for replay is below */
 #dropbox {
   border-style: solid;
   border-color: var(--color);
   border-width: 2px;
 }
-
 .btn-container {
   display: flex;
   align-items: center;
   justify-content: flex-start;
 }
-
 .btn-container.left {
   grid-column-start: 1;
   justify-content: flex-start;
 }
-
 .btn-container.right {
   grid-column-start: 2;
   justify-content: flex-end;
 }
-
 #scrubber-range-input {
   width: var(--canvas-width);
   height: var(--btn-height);
 }
-
 span.margin-left-right {
   margin-left: calc(var(--font-size) / 1.5);
   margin-right: calc(var(--font-size) / 1.5);
 }
-
 button.btn-for-replay {
   height: var(--btn-height);
   width: calc(var(--btn-width) / 2);
   font-size: calc(var(--font-size) / 1.2);
 }
-
 button.btn-for-replay.selected {
   background-color: rgb(50, 163, 255);
   background-image: none;
   color: white;
   font-weight: bold;
 }
-
 #play-pause-btn {
   font-size: var(--font-size);
 }
-
 div.inline {
   display: inline;
 }
-
 div.margin-top-little {
   margin-top: calc(var(--font-size) / 1.5);
 }
-
 input[type='file'] {
   display: none;
 }
-
 label.custom-file-upload {
   display: flex;
   justify-content: center;
@@ -903,18 +771,15 @@ label.custom-file-upload {
   height: var(--btn-height);
   cursor: pointer;
 }
-
 .disable-dbl-tap-zoom {
   touch-action: manipulation;
 }
-
 .flex-for-keyboard {
   display: flex;
   flex-direction: row;
   justify-content: space-around;
   margin-top: 10px;
 }
-
 .grid-for-keyboard {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
@@ -923,37 +788,31 @@ label.custom-file-upload {
   width: calc(5 * var(--btn-height));
   height: calc(2.3 * var(--btn-height));
 }
-
 #z-key,
 #enter-key {
   grid-row-start: 1;
   grid-column-start: 1;
 }
-
 #r-key,
 #up-key {
   grid-row-start: 1;
   grid-column-start: 3;
 }
-
 #d-key,
 #left-key {
   grid-row-start: 2;
   grid-column-start: 2;
 }
-
 #v-key,
 #down-key {
   grid-row-start: 2;
   grid-column-start: 3;
 }
-
 #g-key,
 #right-key {
   grid-row-start: 2;
   grid-column-start: 4;
 }
-
 .keyboard-key {
   display: flex;
   justify-content: center;
@@ -961,47 +820,38 @@ label.custom-file-upload {
   border: 2px solid rgb(50, 50, 50);
   font-size: var(--font-size);
 }
-
 .keyboard-key.pressed {
   background-color: rgb(255, 0, 0);
   color: white;
 }
-
 #show-hide-keyboard-btn {
   font-size: calc(var(--font-size) / 1.3);
   width: var(--btn-width);
 }
-
 div.show-checkboxes-container {
   font-size: calc(var(--font-size) / 1.2);
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
 }
-
 label[for='fps-input'] {
   margin-left: 10px;
 }
-
 #fps-input {
   height: var(--btn-height);
   width: calc(var(--btn-width) / 2);
   font-size: calc(var(--font-size) / 1.2);
 }
-
 .open-chat-list {
   margin-block-start: 1em;
   margin-block-end: 0;
 }
-
 .open-chat-list li {
   margin-top: 10px;
 }
-
 .no-margin-top {
   margin-top: 0;
 }
-
 .if-embedded-in-other-website {
   display: flex;
   flex-direction: column;
@@ -1014,11 +864,9 @@ label[for='fps-input'] {
   border: 3px solid;
   border-radius: 10px;
 }
-
 .if-embedded-in-other-website .limit-width {
   max-width: calc(23 * var(--font-size));
 }
-
 .if-embedded-in-other-website button {
   margin-top: var(--font-size);
   background-color: var(--background-color);
@@ -1028,11 +876,9 @@ label[for='fps-input'] {
   height: calc(1.6 * var(--font-size));
   width: calc(4 * var(--font-size));
 }
-
 .original-address {
   margin-top: var(--font-size);
 }
-
 table.blocked-ip-addresses-table {
   /* box-sizing below is necessary for Chrome and Safari, not for Firefox.
      Is it a bug in Chrome and Safari? */
@@ -1041,45 +887,37 @@ table.blocked-ip-addresses-table {
   border: 2px solid rgb(200, 200, 200);
   width: 100%;
 }
-
 table.blocked-ip-addresses-table th,
 table.blocked-ip-addresses-table td {
   border: 1px solid rgb(190, 190, 190);
   padding: 5px;
   text-align: center;
 }
-
 table.blocked-ip-addresses-table tbody td {
   cursor: default;
 }
-
 table.blocked-ip-addresses-table tfoot td {
   padding: 0;
 }
-
 table.blocked-ip-addresses-table tr.selected {
   background-color: var(--link-hover-color);
 }
-
 table.blocked-ip-addresses-table input {
   width: 100%;
   height: 100%;
   border: none;
   font-size: var(--font-size);
 }
-
 table.blocked-ip-addresses-table .delete-btn {
   height: 100%;
   width: 100%;
   font-size: var(--font-size);
 }
-
 details {
   border: 1px solid #aaa;
   border-radius: 4px;
   padding: 0;
 }
-
 summary {
   /* box-sizing below is necessary for Chrome and Safari, not for Firefox.
      Is it a bug in Chrome and Safari? */
@@ -1087,7 +925,6 @@ summary {
   font-weight: bold;
   padding: 0.5em;
 }
-
 div.color-scheme-toggle-switch-container {
   display: flex;
   justify-content: center;
@@ -1108,7 +945,6 @@ div.color-scheme-toggle-switch-container {
       var(--toggle-ball-left)
   );
 }
-
 /*
  * Toggle switch using CSS
  * Reference: https://dev.to/karankmr/how-to-create-a-custom-toggle-switch-using-css-4pmi
@@ -1116,7 +952,6 @@ div.color-scheme-toggle-switch-container {
 input.toggle-switch {
   display: none;
 }
-
 input.toggle-switch + label {
   display: inline-block;
   position: relative;
@@ -1128,7 +963,6 @@ input.toggle-switch + label {
   cursor: pointer;
   transition: background-color 1s;
 }
-
 input.toggle-switch + label::after {
   content: '';
   position: absolute;
@@ -1140,11 +974,9 @@ input.toggle-switch + label::after {
   background-color: var(--btn-color);
   transition: left 0.5s, background-color 1s;
 }
-
 input.toggle-switch:checked + label::after {
   left: var(--toggle-ball-left-toggled);
 }
-
 /*
  * The following supplement is for displaying the Sun and Moon unicode characters
  * inside toggle switch label.
@@ -1162,7 +994,6 @@ input.toggle-switch + label::before {
   font-size: var(--toggle-ball-diameter);
   content: '\2600';
 }
-
 input.toggle-switch:checked + label::before {
   left: var(--toggle-ball-left);
   content: '\263E';


### PR DESCRIPTION
Add webrtc additional setting

I wanted to add a turn server to communicate with the internal network, but the rtc_configuration.js file contained static addresses.

So, I tried to modify it so that you can add additional servers from the webpage.

If there is such a feature, I expect that if someone provides a TURN server, I can enter its address and the WEBRTC communication will work well even in the internal network.

The test was done with an open source program called coturn.

Feel free to change it or stay with it. I hope the feature will be added to the main branch

Thank you

---

내부망 끼리 통신을 위해서 turn 서버 추가를 하고싶은데 rtc_configuration.js 파일에 static 하게 주소가 들어있더라고요.

따라서, 웹페이지에서 추가적인 서버 추가를 할 수 있도록 수정 해 보았습니다.

해당 기능이 있으면 누군가 turn서버를 제공하면 그 주소를 입력하여 내부망에서도 webrtc 통신이 잘 동작 할 것으로 기대합니다.

테스트는 coturn 이라는 오픈소스 프로그램으로 수행하였습니다.

변경하셔도 되고 바로 머지하셔도 됩니다. 기능이 메인 브랜치에 추가 되었으면 좋겠습니다

감사합니다